### PR TITLE
Add English README and Japanese documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
 # wezterm-agent-dashboard
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+A WezTerm plugin that provides a real-time dashboard for monitoring AI coding agents (e.g. Claude Code) running in your terminal.
+
+> [日本語ドキュメント (Japanese)](docs/README_ja.md)
+
+## Overview
+
+wezterm-agent-dashboard displays a status bar and dashboard overlay inside [WezTerm](https://wezfurlong.org/wezterm/) that tracks the activity of AI coding agents. Monitor token usage, active tasks, session duration, and more — all without leaving your terminal.
+
+## Features
+
+- Real-time monitoring of AI agent sessions
+- Token usage and cost tracking
+- Active task and tool call visualization
+- Lightweight status bar integration with WezTerm
+- Dashboard overlay toggled via keybinding
+- Support for multiple concurrent agent sessions
+
+## Requirements
+
+- [WezTerm](https://wezfurlong.org/wezterm/) (nightly or v20240101+)
+- Rust 1.75+ (for building from source)
+
+## Installation
+
+### From source
+
+```sh
+git clone https://github.com/0maru/wezterm-agent-dashboard.git
+cd wezterm-agent-dashboard
+cargo build --release
+```
+
+### WezTerm configuration
+
+Add the following to your `~/.wezterm.lua`:
+
+```lua
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+
+-- Load the agent dashboard plugin
+local agent_dashboard = wezterm.plugin.require("https://github.com/0maru/wezterm-agent-dashboard")
+
+agent_dashboard.apply_to_config(config)
+
+return config
+```
+
+## Usage
+
+Once installed, the dashboard status bar appears automatically when an AI agent session is detected.
+
+| Keybinding | Action |
+|---|---|
+| `Ctrl+Shift+A` | Toggle dashboard overlay |
+
+## Configuration
+
+You can customize the plugin by passing options to `apply_to_config`:
+
+```lua
+agent_dashboard.apply_to_config(config, {
+  position = "bottom",    -- "top" or "bottom"
+  update_interval = 1000, -- refresh interval in ms
+})
+```
+
+## Development
+
+```sh
+# Run tests
+cargo test
+
+# Run with debug logging
+RUST_LOG=debug cargo run
+```
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -1,0 +1,94 @@
+# wezterm-agent-dashboard
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../LICENSE)
+
+WezTerm 上で AI コーディングエージェント（Claude Code など）の動作状況をリアルタイムに監視するダッシュボードプラグインです。
+
+> [English](../README.md)
+
+## 概要
+
+wezterm-agent-dashboard は、[WezTerm](https://wezfurlong.org/wezterm/) 内にステータスバーとダッシュボードオーバーレイを表示し、AI コーディングエージェントのアクティビティを追跡します。トークン使用量、実行中のタスク、セッション時間などをターミナルから離れることなく確認できます。
+
+## 機能
+
+- AI エージェントセッションのリアルタイム監視
+- トークン使用量・コストの追跡
+- 実行中のタスク・ツール呼び出しの可視化
+- WezTerm ステータスバーへの軽量な統合
+- キーバインドで切り替え可能なダッシュボードオーバーレイ
+- 複数エージェントセッションの同時監視に対応
+
+## 必要環境
+
+- [WezTerm](https://wezfurlong.org/wezterm/)（nightly または v20240101 以降）
+- Rust 1.75 以上（ソースからビルドする場合）
+
+## インストール
+
+### ソースからビルド
+
+```sh
+git clone https://github.com/0maru/wezterm-agent-dashboard.git
+cd wezterm-agent-dashboard
+cargo build --release
+```
+
+### WezTerm の設定
+
+`~/.wezterm.lua` に以下を追加してください：
+
+```lua
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+
+-- エージェントダッシュボードプラグインを読み込み
+local agent_dashboard = wezterm.plugin.require("https://github.com/0maru/wezterm-agent-dashboard")
+
+agent_dashboard.apply_to_config(config)
+
+return config
+```
+
+## 使い方
+
+インストール後、AI エージェントのセッションが検出されると自動的にダッシュボードのステータスバーが表示されます。
+
+| キーバインド | 動作 |
+|---|---|
+| `Ctrl+Shift+A` | ダッシュボードオーバーレイの表示切り替え |
+
+## 設定
+
+`apply_to_config` にオプションを渡すことでカスタマイズできます：
+
+```lua
+agent_dashboard.apply_to_config(config, {
+  position = "bottom",    -- "top" または "bottom"
+  update_interval = 1000, -- 更新間隔（ミリ秒）
+})
+```
+
+## 開発
+
+```sh
+# テストの実行
+cargo test
+
+# デバッグログ付きで実行
+RUST_LOG=debug cargo run
+```
+
+## コントリビュート
+
+コントリビュートを歓迎します！Issue の作成やプルリクエストの送信をお気軽にどうぞ。
+
+1. リポジトリをフォーク
+2. フィーチャーブランチを作成（`git checkout -b feature/amazing-feature`）
+3. 変更をコミット（`git commit -m 'Add amazing feature'`）
+4. ブランチにプッシュ（`git push origin feature/amazing-feature`）
+5. プルリクエストを作成
+
+## ライセンス
+
+このプロジェクトは MIT ライセンスの下で公開されています。詳細は [LICENSE](../LICENSE) を参照してください。


### PR DESCRIPTION
Create comprehensive README.md in English with project overview,
installation, usage, and configuration sections. Add Japanese
translation at docs/README_ja.md with cross-links between both versions.

https://claude.ai/code/session_016qJJd5ADWv6CmEBVJs99fu