### PR TITLE
プラグインエントリポイントを plugin/init.lua に移動

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,4 +1,4 @@
--- wezterm-agent-dashboard.lua
+-- wezterm-agent-dashboard / plugin/init.lua
 -- WezTerm Lua module for agent dashboard integration.
 --
 -- Provides:
@@ -6,7 +6,7 @@
 --   2. Keybinding to toggle the dashboard sidebar
 --
 -- Usage in wezterm.lua:
---   local dashboard = require("wezterm-agent-dashboard")
+--   local dashboard = wezterm.plugin.require("https://github.com/0maru/wezterm-agent-dashboard")
 --   dashboard.setup({ toggle_key = { key = "e", mods = "LEADER" } })
 --   dashboard.apply_to_config(config)
 


### PR DESCRIPTION
## 概要
- `wezterm.plugin.require()` の規約に合わせ、Lua モジュールを `plugin/init.lua` に移動
- これまで `lua/wezterm-agent-dashboard.lua` にしかファイルがなく、URL ベースでロードすると module not found で WezTerm の設定読み込みが失敗していた
- ヘッダコメントの使用例も README と整合させる

## テスト計画
- [ ] 別の WezTerm 設定から \`wezterm.plugin.require(\"https://github.com/0maru/wezterm-agent-dashboard\")\` でロードできることを確認
- [ ] \`agent_dashboard.apply_to_config(config)\` でステータスバーとトグルキーが正しく登録される

🤖 Generated with [Claude Code](https://claude.com/claude-code)