### PR TITLE
リポジトリフィルタを表示名ではなく安定した識別子で管理する

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -16,6 +16,7 @@ pub struct PaneGitInfo {
 
 #[derive(Debug, Clone)]
 pub struct RepoGroup {
+    pub id: String,
     pub name: String,
     pub has_focus: bool,
     pub panes: Vec<(PaneInfo, PaneGitInfo)>,
@@ -133,7 +134,7 @@ pub fn group_panes_by_repo(
         }
     }
 
-    groups
+    let mut result: Vec<RepoGroup> = groups
         .into_iter()
         .map(|(key, panes)| {
             let name = std::path::Path::new(&key)
@@ -145,10 +146,87 @@ pub fn group_panes_by_repo(
                 focused_pane_id.is_some_and(|fid| panes.iter().any(|(p, _)| p.pane_id == fid));
 
             RepoGroup {
+                id: key,
                 name,
                 has_focus,
                 panes,
             }
         })
-        .collect()
+        .collect();
+
+    disambiguate_names(&mut result);
+
+    result
+}
+
+fn disambiguate_names(groups: &mut [RepoGroup]) {
+    let mut name_count: HashMap<String, usize> = HashMap::new();
+    for g in groups.iter() {
+        *name_count.entry(g.name.clone()).or_default() += 1;
+    }
+
+    for g in groups.iter_mut() {
+        if name_count.get(&g.name).copied().unwrap_or(0) > 1 {
+            let path = std::path::Path::new(&g.id);
+            if let (Some(parent), Some(file_name)) = (
+                path.parent().and_then(|p| p.file_name()),
+                path.file_name(),
+            ) {
+                g.name = format!(
+                    "{}/{}",
+                    parent.to_string_lossy(),
+                    file_name.to_string_lossy()
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_group(id: &str, name: &str) -> RepoGroup {
+        RepoGroup {
+            id: id.into(),
+            name: name.into(),
+            has_focus: false,
+            panes: vec![],
+        }
+    }
+
+    #[test]
+    fn test_disambiguate_unique_names() {
+        let mut groups = vec![
+            make_test_group("/home/user/src/foo", "foo"),
+            make_test_group("/home/user/src/bar", "bar"),
+        ];
+        disambiguate_names(&mut groups);
+        assert_eq!(groups[0].name, "foo");
+        assert_eq!(groups[1].name, "bar");
+    }
+
+    #[test]
+    fn test_disambiguate_duplicate_names() {
+        let mut groups = vec![
+            make_test_group("/home/user/src/foo/api", "api"),
+            make_test_group("/home/user/src/bar/api", "api"),
+        ];
+        disambiguate_names(&mut groups);
+        assert_eq!(groups[0].name, "foo/api");
+        assert_eq!(groups[1].name, "bar/api");
+    }
+
+    #[test]
+    fn test_disambiguate_mixed() {
+        let mut groups = vec![
+            make_test_group("/home/user/src/foo/api", "api"),
+            make_test_group("/home/user/src/bar/api", "api"),
+            make_test_group("/home/user/src/web", "web"),
+        ];
+        disambiguate_names(&mut groups);
+        assert_eq!(groups[0].name, "foo/api");
+        assert_eq!(groups[1].name, "bar/api");
+        assert_eq!(groups[2].name, "web");
+    }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -168,10 +168,9 @@ fn disambiguate_names(groups: &mut [RepoGroup]) {
     for g in groups.iter_mut() {
         if name_count.get(&g.name).copied().unwrap_or(0) > 1 {
             let path = std::path::Path::new(&g.id);
-            if let (Some(parent), Some(file_name)) = (
-                path.parent().and_then(|p| p.file_name()),
-                path.file_name(),
-            ) {
+            if let (Some(parent), Some(file_name)) =
+                (path.parent().and_then(|p| p.file_name()), path.file_name())
+            {
                 g.name = format!(
                     "{}/{}",
                     parent.to_string_lossy(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,12 +149,13 @@ fn run_app(
                         (KeyCode::Enter, _) if state.focus == Focus::Agents => {
                             if state.repo_popup_open {
                                 // Select repo filter
-                                let names = state.repo_names();
+                                let entries = state.repo_entries();
                                 if state.repo_popup_selected == 0 {
                                     state.repo_filter = RepoFilter::All;
-                                } else if let Some(name) = names.get(state.repo_popup_selected - 1)
+                                } else if let Some((id, _name)) =
+                                    entries.get(state.repo_popup_selected - 1)
                                 {
-                                    state.repo_filter = RepoFilter::Repo(name.clone());
+                                    state.repo_filter = RepoFilter::Repo(id.clone());
                                 }
                                 state.repo_popup_open = false;
                                 state.refresh();
@@ -171,7 +172,7 @@ fn run_app(
 
                         // Popup navigation
                         (KeyCode::Char('j') | KeyCode::Down, _) if state.repo_popup_open => {
-                            let max = state.repo_names().len();
+                            let max = state.repo_entries().len();
                             if state.repo_popup_selected < max {
                                 state.repo_popup_selected += 1;
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,10 +177,10 @@ fn run_app(
                                 state.repo_popup_selected += 1;
                             }
                         }
-                        (KeyCode::Char('k') | KeyCode::Up, _) if state.repo_popup_open => {
-                            if state.repo_popup_selected > 0 {
-                                state.repo_popup_selected -= 1;
-                            }
+                        (KeyCode::Char('k') | KeyCode::Up, _)
+                            if state.repo_popup_open && state.repo_popup_selected > 0 =>
+                        {
+                            state.repo_popup_selected -= 1;
                         }
 
                         // Escape closes popup or clears filter
@@ -225,11 +225,9 @@ fn run_app(
                                 state.activity_scroll.scroll(3);
                             }
                         }
-                        MouseEventKind::Down(_) => {
-                            // Simple click handling: close popup on any click outside
-                            if state.repo_popup_open {
-                                state.repo_popup_open = false;
-                            }
+                        // Simple click handling: close popup on any click outside
+                        MouseEventKind::Down(_) if state.repo_popup_open => {
+                            state.repo_popup_open = false;
                         }
                         _ => {}
                     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -240,10 +240,10 @@ impl AppState {
     }
 
     /// Rebuild the flat list of selectable agent rows from groups.
-    fn rebuild_row_targets(&mut self) {
+    pub(crate) fn rebuild_row_targets(&mut self) {
         // Validate repo filter
-        if let RepoFilter::Repo(ref name) = self.repo_filter
-            && !self.repo_groups.iter().any(|g| g.name == *name)
+        if let RepoFilter::Repo(ref id) = self.repo_filter
+            && !self.repo_groups.iter().any(|g| g.id == *id)
         {
             self.repo_filter = RepoFilter::All;
         }
@@ -251,8 +251,8 @@ impl AppState {
         self.agent_row_targets.clear();
 
         for group in &self.repo_groups {
-            if let RepoFilter::Repo(ref name) = self.repo_filter
-                && group.name != *name
+            if let RepoFilter::Repo(ref id) = self.repo_filter
+                && group.id != *id
             {
                 continue;
             }
@@ -335,8 +335,8 @@ impl AppState {
         let mut error = 0;
 
         for group in &self.repo_groups {
-            if let RepoFilter::Repo(ref name) = self.repo_filter
-                && group.name != *name
+            if let RepoFilter::Repo(ref id) = self.repo_filter
+                && group.id != *id
             {
                 continue;
             }
@@ -381,9 +381,12 @@ impl AppState {
         }
     }
 
-    /// Get unique repo names for the repo filter popup.
-    pub fn repo_names(&self) -> Vec<String> {
-        self.repo_groups.iter().map(|g| g.name.clone()).collect()
+    /// Get repo entries for the filter popup: (id, display_name).
+    pub fn repo_entries(&self) -> Vec<(String, String)> {
+        self.repo_groups
+            .iter()
+            .map(|g| (g.id.clone(), g.name.clone()))
+            .collect()
     }
 
     /// Find a specific pane by ID across all groups.
@@ -574,6 +577,7 @@ mod tests {
     #[test]
     fn test_status_counts() {
         let groups = vec![RepoGroup {
+            id: "/tmp/project".into(),
             name: "project".into(),
             has_focus: false,
             panes: vec![
@@ -597,11 +601,13 @@ mod tests {
     fn test_status_counts_with_repo_filter() {
         let groups = vec![
             RepoGroup {
+                id: "/tmp/project-a".into(),
                 name: "project-a".into(),
                 has_focus: false,
                 panes: vec![(make_pane(1, PaneStatus::Running), make_git_info())],
             },
             RepoGroup {
+                id: "/tmp/project-b".into(),
                 name: "project-b".into(),
                 has_focus: false,
                 panes: vec![
@@ -611,7 +617,7 @@ mod tests {
             },
         ];
         let mut state = make_state_with_groups(groups);
-        state.repo_filter = RepoFilter::Repo("project-b".into());
+        state.repo_filter = RepoFilter::Repo("/tmp/project-b".into());
 
         let (all, running, _waiting, idle, error) = state.status_counts();
         assert_eq!(all, 2);
@@ -623,6 +629,7 @@ mod tests {
     #[test]
     fn test_select_prev_next() {
         let groups = vec![RepoGroup {
+            id: "/tmp/project".into(),
             name: "project".into(),
             has_focus: false,
             panes: vec![
@@ -654,6 +661,7 @@ mod tests {
     #[test]
     fn test_selected_pane() {
         let groups = vec![RepoGroup {
+            id: "/tmp/project".into(),
             name: "project".into(),
             has_focus: false,
             panes: vec![
@@ -677,6 +685,7 @@ mod tests {
     #[test]
     fn test_find_pane() {
         let groups = vec![RepoGroup {
+            id: "/tmp/project".into(),
             name: "project".into(),
             has_focus: false,
             panes: vec![
@@ -692,20 +701,86 @@ mod tests {
     }
 
     #[test]
-    fn test_repo_names() {
+    fn test_repo_entries() {
         let groups = vec![
             RepoGroup {
+                id: "/tmp/alpha".into(),
                 name: "alpha".into(),
                 has_focus: false,
                 panes: vec![(make_pane(1, PaneStatus::Running), make_git_info())],
             },
             RepoGroup {
+                id: "/tmp/beta".into(),
                 name: "beta".into(),
                 has_focus: true,
                 panes: vec![(make_pane(2, PaneStatus::Idle), make_git_info())],
             },
         ];
         let state = make_state_with_groups(groups);
-        assert_eq!(state.repo_names(), vec!["alpha", "beta"]);
+        let entries = state.repo_entries();
+        assert_eq!(
+            entries,
+            vec![
+                ("/tmp/alpha".to_string(), "alpha".to_string()),
+                ("/tmp/beta".to_string(), "beta".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_repo_filter_with_same_basename() {
+        let groups = vec![
+            RepoGroup {
+                id: "/home/user/foo/api".into(),
+                name: "foo/api".into(),
+                has_focus: false,
+                panes: vec![(make_pane(1, PaneStatus::Running), make_git_info())],
+            },
+            RepoGroup {
+                id: "/home/user/bar/api".into(),
+                name: "bar/api".into(),
+                has_focus: false,
+                panes: vec![
+                    (make_pane(2, PaneStatus::Idle), make_git_info()),
+                    (make_pane(3, PaneStatus::Error), make_git_info()),
+                ],
+            },
+        ];
+        let mut state = make_state_with_groups(groups);
+
+        // Filter to foo/api by id
+        state.repo_filter = RepoFilter::Repo("/home/user/foo/api".into());
+        state.rebuild_row_targets();
+
+        let (all, running, _, _, _) = state.status_counts();
+        assert_eq!(all, 1);
+        assert_eq!(running, 1);
+
+        // Filter to bar/api by id
+        state.repo_filter = RepoFilter::Repo("/home/user/bar/api".into());
+        state.rebuild_row_targets();
+
+        let (all, _, _, idle, error) = state.status_counts();
+        assert_eq!(all, 2);
+        assert_eq!(idle, 1);
+        assert_eq!(error, 1);
+    }
+
+    #[test]
+    fn test_repo_filter_validation_uses_id() {
+        let groups = vec![RepoGroup {
+            id: "/home/user/project".into(),
+            name: "project".into(),
+            has_focus: false,
+            panes: vec![(make_pane(1, PaneStatus::Running), make_git_info())],
+        }];
+        let mut state = make_state_with_groups(groups);
+
+        // Set a filter with a non-existent id
+        state.repo_filter = RepoFilter::Repo("/nonexistent".into());
+        state.rebuild_row_targets();
+
+        // Should have been reset to All
+        assert_eq!(state.repo_filter, RepoFilter::All);
     }
 }

--- a/src/ui/agents.rs
+++ b/src/ui/agents.rs
@@ -76,10 +76,17 @@ impl Widget for FilterBar<'_> {
         }
 
         // Repo filter button
-        if let RepoFilter::Repo(ref name) = self.state.repo_filter {
+        if let RepoFilter::Repo(ref id) = self.state.repo_filter {
+            let display = self
+                .state
+                .repo_groups
+                .iter()
+                .find(|g| g.id == *id)
+                .map(|g| g.name.as_str())
+                .unwrap_or(id.as_str());
             spans.push(Span::raw("  "));
             spans.push(Span::styled(
-                format!("▼{name}"),
+                format!("▼{display}"),
                 Style::default().fg(self.state.theme.active_border),
             ));
         }
@@ -108,8 +115,8 @@ impl Widget for AgentList<'_> {
         let max_y = area.y + area.height;
 
         for (group_idx, group) in self.state.repo_groups.iter().enumerate() {
-            if let RepoFilter::Repo(ref name) = self.state.repo_filter
-                && group.name != *name
+            if let RepoFilter::Repo(ref id) = self.state.repo_filter
+                && group.id != *id
             {
                 continue;
             }
@@ -346,7 +353,7 @@ impl Widget for RepoPopup<'_> {
             }
         }
 
-        let names = self.state.repo_names();
+        let entries = self.state.repo_entries();
         let mut y = area.y + 1;
 
         // "All" option
@@ -361,8 +368,8 @@ impl Widget for RepoPopup<'_> {
             y += 1;
         }
 
-        // Repo names
-        for (i, name) in names.iter().enumerate() {
+        // Repo entries
+        for (i, (_id, name)) in entries.iter().enumerate() {
             if y >= area.y + area.height - 1 {
                 break;
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -78,9 +78,14 @@ impl Widget for Dashboard<'_> {
 
         // Repo filter popup (if open)
         if self.state.repo_popup_open {
-            let popup_width = 30.min(area.width - 2);
-            let names = self.state.repo_names();
-            let popup_height = (names.len() as u16 + 3).min(area.height - 2);
+            let entries = self.state.repo_entries();
+            let max_name_len = entries
+                .iter()
+                .map(|(_, name)| unicode_width::UnicodeWidthStr::width(name.as_str()))
+                .max()
+                .unwrap_or(3);
+            let popup_width = ((max_name_len + 4) as u16).clamp(15, area.width - 2);
+            let popup_height = (entries.len() as u16 + 3).min(area.height - 2);
 
             let popup_area = Rect {
                 x: area.x + 1,


### PR DESCRIPTION
## 概要
- `RepoGroup` に `id`（フルパス）フィールドを追加し、`name` を表示専用ラベルに分離
- `RepoFilter::Repo` の照合を basename から id（フルパス）ベースに変更し、同名リポジトリを正しく区別可能に
- 同名 basename が複数ある場合、popup 表示を `parent/basename` 形式で自動区別する `disambiguate_names` を追加

## テスト計画
- [x] `cargo test` — 全114テスト通過（既存テスト更新 + 新規5テスト追加）
- [x] `cargo clippy` — 警告なし
- [ ] 同名リポジトリが複数ある環境で popup フィルタが正しく動作することを確認
- [ ] 単一リポジトリ環境で既存の挙動に回帰がないことを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/claude-code)