### PR TITLE
未使用 state と未接続ロジックを削減してコードの意図を揃える

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -191,6 +191,55 @@ fn fetch_pr_number(cwd: &str) -> Option<u32> {
 }
 
 // ---------------------------------------------------------------------------
+// Background polling thread
+// ---------------------------------------------------------------------------
+
+/// Start a background thread that polls git data every 2 seconds.
+/// Only polls when `active` flag is true (git tab visible).
+pub fn start_git_poll_thread(
+    active: Arc<AtomicBool>,
+) -> (
+    mpsc::Receiver<GitData>,
+    Arc<AtomicBool>,
+    thread::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::channel();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+
+    let handle = thread::spawn(move || {
+        loop {
+            if shutdown_clone.load(Ordering::Relaxed) {
+                break;
+            }
+
+            thread::sleep(Duration::from_secs(2));
+
+            if !active.load(Ordering::Relaxed) {
+                continue;
+            }
+
+            let path_file = "/tmp/wezterm-agent-dashboard-git-path";
+            let path = std::fs::read_to_string(path_file)
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+
+            if path.is_empty() {
+                continue;
+            }
+
+            let data = fetch_git_data(&path);
+            if tx.send(data).is_err() {
+                break;
+            }
+        }
+    });
+
+    (rx, shutdown, handle)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -329,61 +378,4 @@ mod tests {
         assert!(data.branch.is_empty());
         assert!(data.path.is_empty());
     }
-}
-
-// ---------------------------------------------------------------------------
-// Background polling thread
-// ---------------------------------------------------------------------------
-
-/// Start a background thread that polls git data every 2 seconds.
-/// Only polls when `active` flag is true (git tab visible).
-pub fn start_git_poll_thread(
-    active: Arc<AtomicBool>,
-) -> (
-    mpsc::Receiver<GitData>,
-    Arc<AtomicBool>,
-    thread::JoinHandle<()>,
-) {
-    let (tx, rx) = mpsc::channel();
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_clone = shutdown.clone();
-
-    let handle = thread::spawn(move || {
-        let mut last_path = String::new();
-
-        loop {
-            if shutdown_clone.load(Ordering::Relaxed) {
-                break;
-            }
-
-            thread::sleep(Duration::from_secs(2));
-
-            if !active.load(Ordering::Relaxed) {
-                continue;
-            }
-
-            // Read the path from a temp file or use a default mechanism
-            // In practice, the main thread writes the focused pane's cwd to this
-            let path_file = "/tmp/wezterm-agent-dashboard-git-path";
-            let path = std::fs::read_to_string(path_file)
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-
-            if path.is_empty() {
-                continue;
-            }
-
-            if path != last_path {
-                last_path = path.clone();
-            }
-
-            let data = fetch_git_data(&last_path);
-            if tx.send(data).is_err() {
-                break;
-            }
-        }
-    });
-
-    (rx, shutdown, handle)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,45 +192,15 @@ fn run_app(
                             }
                         }
 
-                        // Activity log scroll
-                        (KeyCode::Char('j') | KeyCode::Down, _)
-                            if state.focus == Focus::ActivityLog =>
-                        {
-                            state.activity_scroll.scroll(1);
-                        }
-                        (KeyCode::Char('k') | KeyCode::Up, _)
-                            if state.focus == Focus::ActivityLog =>
-                        {
-                            state.activity_scroll.scroll(-1);
-                        }
-
                         _ => {}
                     }
                 }
 
                 Event::Mouse(mouse) => {
-                    match mouse.kind {
-                        MouseEventKind::ScrollUp => {
-                            if state.focus == Focus::Agents {
-                                state.agents_scroll.scroll(-3);
-                            } else {
-                                state.activity_scroll.scroll(-3);
-                            }
-                        }
-                        MouseEventKind::ScrollDown => {
-                            if state.focus == Focus::Agents {
-                                state.agents_scroll.scroll(3);
-                            } else {
-                                state.activity_scroll.scroll(3);
-                            }
-                        }
-                        MouseEventKind::Down(_) => {
-                            // Simple click handling: close popup on any click outside
-                            if state.repo_popup_open {
-                                state.repo_popup_open = false;
-                            }
-                        }
-                        _ => {}
+                    if let MouseEventKind::Down(_) = mouse.kind
+                        && state.repo_popup_open
+                    {
+                        state.repo_popup_open = false;
                     }
                 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,8 @@ use crate::ui::colors::ColorTheme;
 use crate::wezterm::{self, AgentType, PaneInfo, PaneStatus, WorkspaceInfo};
 use std::collections::{HashMap, HashSet};
 
+const ACTIVITY_MAX_ENTRIES: usize = 8;
+
 // ---------------------------------------------------------------------------
 // Enums
 // ---------------------------------------------------------------------------
@@ -90,33 +92,6 @@ pub struct RowTarget {
 }
 
 // ---------------------------------------------------------------------------
-// Scroll state
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Default)]
-pub struct ScrollState {
-    pub offset: usize,
-    pub total_lines: usize,
-    pub visible_height: usize,
-}
-
-impl ScrollState {
-    pub fn scroll(&mut self, delta: isize) {
-        let max = self.total_lines.saturating_sub(self.visible_height);
-        if delta > 0 {
-            self.offset = (self.offset + delta as usize).min(max);
-        } else {
-            self.offset = self.offset.saturating_sub((-delta) as usize);
-        }
-    }
-
-    pub fn clamp(&mut self) {
-        let max = self.total_lines.saturating_sub(self.visible_height);
-        self.offset = self.offset.min(max);
-    }
-}
-
-// ---------------------------------------------------------------------------
 // AppState
 // ---------------------------------------------------------------------------
 
@@ -125,24 +100,18 @@ pub struct AppState {
     pub workspaces: Vec<WorkspaceInfo>,
     pub repo_groups: Vec<RepoGroup>,
     pub dashboard_pane_id: u64,
-    pub sidebar_focused: bool,
     pub focus: Focus,
     pub spinner_frame: usize,
 
     // Agent list
     pub selected_agent_row: usize,
     pub agent_row_targets: Vec<RowTarget>,
-    pub agents_scroll: ScrollState,
-    pub line_to_row: Vec<Option<usize>>,
 
     // Activity log
     pub activity_entries: Vec<ActivityEntry>,
-    pub activity_scroll: ScrollState,
-    pub activity_max_entries: usize,
 
     // Focused pane tracking
     pub focused_pane_id: Option<u64>,
-    pub prev_focused_pane_id: Option<u64>,
 
     // Theme
     pub theme: ColorTheme,
@@ -150,24 +119,15 @@ pub struct AppState {
     // Bottom panel
     pub bottom_tab: BottomTab,
     pub git: GitData,
-    pub git_scroll: ScrollState,
 
     // Task progress
     pub pane_task_progress: HashMap<u64, TaskProgress>,
-    pub pane_task_dismissed: HashMap<u64, usize>,
-    pub pane_inactive_since: HashMap<u64, u64>,
-
-    // Agent tracking
-    pub seen_agent_panes: HashSet<u64>,
-    pub pane_tab_prefs: HashMap<u64, BottomTab>,
 
     // Filters
     pub agent_filter: AgentFilter,
     pub repo_filter: RepoFilter,
     pub repo_popup_open: bool,
     pub repo_popup_selected: usize,
-    pub repo_popup_area: Option<ratatui::layout::Rect>,
-    pub repo_button_col: u16,
 }
 
 impl AppState {
@@ -177,33 +137,20 @@ impl AppState {
             workspaces: Vec::new(),
             repo_groups: Vec::new(),
             dashboard_pane_id,
-            sidebar_focused: false,
             focus: Focus::Agents,
             spinner_frame: 0,
             selected_agent_row: 0,
             agent_row_targets: Vec::new(),
-            agents_scroll: ScrollState::default(),
-            line_to_row: Vec::new(),
             activity_entries: Vec::new(),
-            activity_scroll: ScrollState::default(),
-            activity_max_entries: 8,
             focused_pane_id: None,
-            prev_focused_pane_id: None,
             theme: ColorTheme::default(),
             bottom_tab: BottomTab::Activity,
             git: GitData::default(),
-            git_scroll: ScrollState::default(),
             pane_task_progress: HashMap::new(),
-            pane_task_dismissed: HashMap::new(),
-            pane_inactive_since: HashMap::new(),
-            seen_agent_panes: HashSet::new(),
-            pane_tab_prefs: HashMap::new(),
             agent_filter: AgentFilter::All,
             repo_filter: RepoFilter::All,
             repo_popup_open: false,
             repo_popup_selected: 0,
-            repo_popup_area: None,
-            repo_button_col: 0,
         }
     }
 
@@ -219,7 +166,6 @@ impl AppState {
         if let Some(fid) = new_focused
             && self.focused_pane_id != Some(fid)
         {
-            self.prev_focused_pane_id = self.focused_pane_id;
             self.focused_pane_id = Some(fid);
         }
 
@@ -282,10 +228,10 @@ impl AppState {
 
     fn refresh_activity(&mut self) {
         if let Some(pane_id) = self.focused_pane_id {
-            self.activity_entries = activity::read_activity_log(pane_id, self.activity_max_entries);
+            self.activity_entries = activity::read_activity_log(pane_id, ACTIVITY_MAX_ENTRIES);
         } else if let Some(first) = self.agent_row_targets.first() {
             self.activity_entries =
-                activity::read_activity_log(first.pane_id, self.activity_max_entries);
+                activity::read_activity_log(first.pane_id, ACTIVITY_MAX_ENTRIES);
         } else {
             self.activity_entries.clear();
         }
@@ -429,7 +375,6 @@ mod tests {
             wait_reason: String::new(),
             permission_mode: PermissionMode::Default,
             subagents: Vec::new(),
-            pane_pid: None,
         }
     }
 
@@ -493,61 +438,6 @@ mod tests {
     fn test_bottom_tab_toggle() {
         assert_eq!(BottomTab::Activity.toggle(), BottomTab::GitStatus);
         assert_eq!(BottomTab::GitStatus.toggle(), BottomTab::Activity);
-    }
-
-    // -- ScrollState tests --
-
-    #[test]
-    fn test_scroll_down() {
-        let mut s = ScrollState {
-            offset: 0,
-            total_lines: 20,
-            visible_height: 10,
-        };
-        s.scroll(5);
-        assert_eq!(s.offset, 5);
-        s.scroll(10);
-        // max = 20 - 10 = 10
-        assert_eq!(s.offset, 10);
-    }
-
-    #[test]
-    fn test_scroll_up() {
-        let mut s = ScrollState {
-            offset: 5,
-            total_lines: 20,
-            visible_height: 10,
-        };
-        s.scroll(-3);
-        assert_eq!(s.offset, 2);
-        s.scroll(-10);
-        assert_eq!(s.offset, 0);
-    }
-
-    #[test]
-    fn test_scroll_clamp() {
-        let mut s = ScrollState {
-            offset: 15,
-            total_lines: 20,
-            visible_height: 10,
-        };
-        s.clamp();
-        assert_eq!(s.offset, 10); // max = 20 - 10 = 10
-
-        s.total_lines = 5;
-        s.clamp();
-        assert_eq!(s.offset, 0); // max = 0 (visible_height > total_lines)
-    }
-
-    #[test]
-    fn test_scroll_when_content_fits() {
-        let mut s = ScrollState {
-            offset: 0,
-            total_lines: 5,
-            visible_height: 10,
-        };
-        s.scroll(5);
-        assert_eq!(s.offset, 0); // max = 0, can't scroll
     }
 
     // -- AppState tests --

--- a/src/user_vars.rs
+++ b/src/user_vars.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn test_decode_non_utf8() {
-        let encoded = base64::engine::general_purpose::STANDARD.encode(&[0xff, 0xfe]);
+        let encoded = base64::engine::general_purpose::STANDARD.encode([0xff, 0xfe]);
         assert_eq!(decode_user_var(&encoded), "");
     }
 }

--- a/src/wezterm.rs
+++ b/src/wezterm.rs
@@ -133,7 +133,6 @@ pub struct PaneInfo {
     pub wait_reason: String,
     pub permission_mode: PermissionMode,
     pub subagents: Vec<String>,
-    pub pane_pid: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -216,9 +215,6 @@ pub fn build_workspaces(
     // workspace_name → (tab_id → TabInfo)
     let mut workspaces: IndexMap<String, IndexMap<u64, TabInfo>> = IndexMap::new();
 
-    // Detect codex permission modes from ps output
-    let codex_modes = detect_codex_modes();
-
     for raw in raw_panes {
         // Skip the dashboard pane itself
         if Some(raw.pane_id) == dashboard_pane_id {
@@ -234,7 +230,7 @@ pub fn build_workspaces(
             continue;
         }
 
-        let pane_info = match parse_pane_info(&raw, &codex_modes) {
+        let pane_info = match parse_pane_info(&raw) {
             Some(p) => p,
             None => continue,
         };
@@ -266,10 +262,7 @@ pub fn build_workspaces(
 
 /// Parse a raw WezTerm pane into a PaneInfo.
 /// Returns None if the pane has no agent_type user variable.
-fn parse_pane_info(
-    raw: &RawWezTermPane,
-    _codex_modes: &HashMap<u32, PermissionMode>,
-) -> Option<PaneInfo> {
+fn parse_pane_info(raw: &RawWezTermPane) -> Option<PaneInfo> {
     let agent_type_str = raw.user_vars.get("agent_type")?;
     let agent = AgentType::from_str(agent_type_str)?;
 
@@ -315,20 +308,11 @@ fn parse_pane_info(
         .cloned()
         .unwrap_or_default();
 
-    let permission_mode = if agent == AgentType::Codex {
-        // For codex, detect from ps if available
-        // pane_pid is not directly available from wezterm cli list,
-        // so we fall back to user var
-        raw.user_vars
-            .get("agent_permission_mode")
-            .map(|s| PermissionMode::from_str(s))
-            .unwrap_or(PermissionMode::Default)
-    } else {
-        raw.user_vars
-            .get("agent_permission_mode")
-            .map(|s| PermissionMode::from_str(s))
-            .unwrap_or(PermissionMode::Default)
-    };
+    let permission_mode = raw
+        .user_vars
+        .get("agent_permission_mode")
+        .map(|s| PermissionMode::from_str(s))
+        .unwrap_or(PermissionMode::Default);
 
     let subagents: Vec<String> = raw
         .user_vars
@@ -353,7 +337,6 @@ fn parse_pane_info(
         wait_reason,
         permission_mode,
         subagents,
-        pane_pid: None,
     })
 }
 
@@ -381,51 +364,6 @@ fn hex_byte(b: u8) -> u8 {
         b'A'..=b'F' => b - b'A' + 10,
         _ => 0,
     }
-}
-
-/// Detect Codex permission modes from running processes.
-fn detect_codex_modes() -> HashMap<u32, PermissionMode> {
-    let mut modes = HashMap::new();
-
-    let output = Command::new("ps").args(["-eo", "pid,args"]).output().ok();
-
-    let output = match output {
-        Some(o) if o.status.success() => o,
-        _ => return modes,
-    };
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    for line in stdout.lines() {
-        let line = line.trim();
-        if !line.contains("codex") {
-            continue;
-        }
-
-        let parts: Vec<&str> = line.splitn(2, char::is_whitespace).collect();
-        if parts.len() < 2 {
-            continue;
-        }
-
-        let pid = match parts[0].trim().parse::<u32>() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let args = parts[1];
-        let mode = if args.contains("--dangerously-bypass-approvals-and-sandbox")
-            || args.contains("--yolo")
-        {
-            PermissionMode::BypassPermissions
-        } else if args.contains("--full-auto") {
-            PermissionMode::Auto
-        } else {
-            continue;
-        };
-
-        modes.insert(pid, mode);
-    }
-
-    modes
 }
 
 // ---------------------------------------------------------------------------
@@ -641,7 +579,6 @@ mod tests {
                         wait_reason: String::new(),
                         permission_mode: PermissionMode::Default,
                         subagents: Vec::new(),
-                        pane_pid: None,
                     },
                     PaneInfo {
                         pane_id: 2,
@@ -659,7 +596,6 @@ mod tests {
                         wait_reason: String::new(),
                         permission_mode: PermissionMode::Default,
                         subagents: Vec::new(),
-                        pane_pid: None,
                     },
                 ],
             }],
@@ -691,7 +627,6 @@ mod tests {
                     wait_reason: String::new(),
                     permission_mode: PermissionMode::Default,
                     subagents: Vec::new(),
-                    pane_pid: None,
                 }],
             }],
         }];


### PR DESCRIPTION
## 概要
- `AppState` から未使用フィールド12個と `ScrollState` 型を削除し、構造をコンパクトに整理
- `detect_codex_modes()` の未接続パイプライン（毎秒 `ps` を実行）と `pane_pid` フィールドを撤去し、`agent_permission_mode` user var を唯一の source of truth に統一
- clippy 警告 2 件の解消と `git.rs` / `main.rs` の冗長なロジックを簡略化

Closes #10

## テスト計画
- [x] `cargo clippy --all-targets --all-features` で警告 0 件
- [x] `cargo test` で 105 テスト全て pass
- [ ] WezTerm 実機でダッシュボード TUI が正常に表示されること
- [ ] permission_mode バッジが表示されること
- [ ] repo popup の開閉が動作すること
- [ ] focused pane の切替が動作すること