### PR TITLE
[codex] refresh パイプラインの同期 I/O を分離

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -68,6 +69,29 @@ impl TaskProgress {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogFingerprint {
+    pub exists: bool,
+    pub len: u64,
+    pub modified: Option<SystemTime>,
+}
+
+impl LogFingerprint {
+    pub fn missing() -> Self {
+        Self {
+            exists: false,
+            len: 0,
+            modified: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ActivitySnapshot {
+    pub display_entries: Vec<ActivityEntry>,
+    pub task_progress: TaskProgress,
+}
+
 // ---------------------------------------------------------------------------
 // File I/O
 // ---------------------------------------------------------------------------
@@ -92,6 +116,38 @@ pub fn read_activity_log(pane_id: u64, max_entries: usize) -> Vec<ActivityEntry>
         .take(max_entries)
         .filter_map(parse_activity_line)
         .collect()
+}
+
+pub fn log_fingerprint(pane_id: u64) -> LogFingerprint {
+    let path = log_file_path(pane_id);
+    match fs::metadata(path) {
+        Ok(meta) => LogFingerprint {
+            exists: true,
+            len: meta.len(),
+            modified: meta.modified().ok(),
+        },
+        Err(_) => LogFingerprint::missing(),
+    }
+}
+
+pub fn read_activity_snapshot(
+    pane_id: u64,
+    display_limit: usize,
+    progress_limit: usize,
+) -> ActivitySnapshot {
+    let entries = read_activity_log(pane_id, display_limit.max(progress_limit));
+    let display_entries = entries.iter().take(display_limit).cloned().collect();
+    let progress_entries = entries
+        .iter()
+        .take(progress_limit)
+        .cloned()
+        .collect::<Vec<_>>();
+    let task_progress = parse_task_progress(&progress_entries);
+
+    ActivitySnapshot {
+        display_entries,
+        task_progress,
+    }
 }
 
 fn parse_activity_line(line: &str) -> Option<ActivityEntry> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -191,6 +191,57 @@ fn fetch_pr_number(cwd: &str) -> Option<u32> {
 }
 
 // ---------------------------------------------------------------------------
+// Background polling thread
+// ---------------------------------------------------------------------------
+
+/// Start a background thread that polls git data every 2 seconds.
+/// Only polls when `active` flag is true (git tab visible).
+pub fn start_git_poll_thread(
+    active: Arc<AtomicBool>,
+) -> (
+    mpsc::Receiver<GitData>,
+    mpsc::Sender<String>,
+    Arc<AtomicBool>,
+    thread::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::channel();
+    let (path_tx, path_rx) = mpsc::channel();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+
+    let handle = thread::spawn(move || {
+        let mut current_path = String::new();
+
+        loop {
+            if shutdown_clone.load(Ordering::Relaxed) {
+                break;
+            }
+
+            while let Ok(path) = path_rx.try_recv() {
+                current_path = path;
+            }
+
+            thread::sleep(Duration::from_secs(2));
+
+            if !active.load(Ordering::Relaxed) {
+                continue;
+            }
+
+            if current_path.is_empty() {
+                continue;
+            }
+
+            let data = fetch_git_data(&current_path);
+            if tx.send(data).is_err() {
+                break;
+            }
+        }
+    });
+
+    (rx, path_tx, shutdown, handle)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -329,61 +380,4 @@ mod tests {
         assert!(data.branch.is_empty());
         assert!(data.path.is_empty());
     }
-}
-
-// ---------------------------------------------------------------------------
-// Background polling thread
-// ---------------------------------------------------------------------------
-
-/// Start a background thread that polls git data every 2 seconds.
-/// Only polls when `active` flag is true (git tab visible).
-pub fn start_git_poll_thread(
-    active: Arc<AtomicBool>,
-) -> (
-    mpsc::Receiver<GitData>,
-    Arc<AtomicBool>,
-    thread::JoinHandle<()>,
-) {
-    let (tx, rx) = mpsc::channel();
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_clone = shutdown.clone();
-
-    let handle = thread::spawn(move || {
-        let mut last_path = String::new();
-
-        loop {
-            if shutdown_clone.load(Ordering::Relaxed) {
-                break;
-            }
-
-            thread::sleep(Duration::from_secs(2));
-
-            if !active.load(Ordering::Relaxed) {
-                continue;
-            }
-
-            // Read the path from a temp file or use a default mechanism
-            // In practice, the main thread writes the focused pane's cwd to this
-            let path_file = "/tmp/wezterm-agent-dashboard-git-path";
-            let path = std::fs::read_to_string(path_file)
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-
-            if path.is_empty() {
-                continue;
-            }
-
-            if path != last_path {
-                last_path = path.clone();
-            }
-
-            let data = fetch_git_data(&last_path);
-            if tx.send(data).is_err() {
-                break;
-            }
-        }
-    });
-
-    (rx, shutdown, handle)
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,6 +1,7 @@
 use crate::wezterm::{PaneInfo, WorkspaceInfo};
 use indexmap::IndexMap;
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,45 @@ pub fn resolve_pane_git_info(path: &str) -> PaneGitInfo {
     }
 }
 
+fn cached_git_info_for_path(
+    path: &str,
+    git_cache: &HashMap<String, PaneGitInfo>,
+) -> Option<PaneGitInfo> {
+    if let Some(info) = git_cache.get(path) {
+        return Some(info.clone());
+    }
+
+    let path = Path::new(path);
+
+    git_cache
+        .values()
+        .filter_map(|info| {
+            let repo_root = info.repo_root.as_ref()?;
+            let repo_path = Path::new(repo_root);
+            if path == repo_path || path.starts_with(repo_path) {
+                Some((repo_root.len(), info.clone()))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(len, _)| *len)
+        .map(|(_, info)| info)
+}
+
+fn resolve_cached_git_info(
+    path: &str,
+    git_cache: &mut HashMap<String, PaneGitInfo>,
+) -> PaneGitInfo {
+    if let Some(info) = cached_git_info_for_path(path, git_cache) {
+        git_cache.insert(path.to_string(), info.clone());
+        return info;
+    }
+
+    let info = resolve_pane_git_info(path);
+    git_cache.insert(path.to_string(), info.clone());
+    info
+}
+
 // ---------------------------------------------------------------------------
 // Grouping
 // ---------------------------------------------------------------------------
@@ -107,18 +147,15 @@ pub fn resolve_pane_git_info(path: &str) -> PaneGitInfo {
 pub fn group_panes_by_repo(
     workspaces: &[WorkspaceInfo],
     focused_pane_id: Option<u64>,
+    git_cache: &mut HashMap<String, PaneGitInfo>,
 ) -> Vec<RepoGroup> {
-    let mut git_cache: HashMap<String, PaneGitInfo> = HashMap::new();
     // group_key → Vec<(PaneInfo, PaneGitInfo)>
     let mut groups: IndexMap<String, Vec<(PaneInfo, PaneGitInfo)>> = IndexMap::new();
 
     for ws in workspaces {
         for tab in &ws.tabs {
             for pane in &tab.panes {
-                let git_info = git_cache
-                    .entry(pane.path.clone())
-                    .or_insert_with(|| resolve_pane_git_info(&pane.path))
-                    .clone();
+                let git_info = resolve_cached_git_info(&pane.path, git_cache);
 
                 let group_key = git_info
                     .repo_root
@@ -151,4 +188,79 @@ pub fn group_panes_by_repo(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wezterm::{AgentType, PaneStatus, PermissionMode, TabInfo};
+
+    fn make_pane(pane_id: u64, path: &str) -> PaneInfo {
+        PaneInfo {
+            pane_id,
+            tab_id: 1,
+            window_id: 1,
+            workspace: "default".into(),
+            pane_active: false,
+            status: PaneStatus::Running,
+            attention: false,
+            agent: AgentType::Codex,
+            path: path.into(),
+            prompt: String::new(),
+            prompt_is_response: false,
+            started_at: None,
+            wait_reason: String::new(),
+            permission_mode: PermissionMode::Default,
+            subagents: Vec::new(),
+            pane_pid: None,
+        }
+    }
+
+    fn make_workspace(panes: Vec<PaneInfo>) -> Vec<WorkspaceInfo> {
+        vec![WorkspaceInfo {
+            workspace_name: "default".into(),
+            tabs: vec![TabInfo {
+                tab_id: 1,
+                tab_title: "tab".into(),
+                tab_active: true,
+                panes,
+            }],
+        }]
+    }
+
+    fn make_git_info(repo_root: &str) -> PaneGitInfo {
+        PaneGitInfo {
+            repo_root: Some(repo_root.into()),
+            branch: Some("main".into()),
+            is_worktree: false,
+        }
+    }
+
+    #[test]
+    fn test_cached_git_info_for_path_reuses_repo_root_prefix() {
+        let mut cache = HashMap::new();
+        cache.insert("/repo".into(), make_git_info("/repo"));
+
+        let info = resolve_cached_git_info("/repo/src/module", &mut cache);
+
+        assert_eq!(info.repo_root.as_deref(), Some("/repo"));
+        assert!(cache.contains_key("/repo/src/module"));
+    }
+
+    #[test]
+    fn test_group_panes_by_repo_reuses_cached_git_info_for_subdirs() {
+        let workspaces = make_workspace(vec![make_pane(1, "/repo"), make_pane(2, "/repo/src")]);
+        let mut cache = HashMap::new();
+        cache.insert("/repo".into(), make_git_info("/repo"));
+
+        let groups = group_panes_by_repo(&workspaces, Some(2), &mut cache);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "repo");
+        assert!(groups[0].has_focus);
+        assert_eq!(groups[0].panes.len(), 2);
+        assert_eq!(groups[0].panes[0].1.repo_root.as_deref(), Some("/repo"));
+        assert_eq!(groups[0].panes[1].1.repo_root.as_deref(), Some("/repo"));
+        assert!(cache.contains_key("/repo/src"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,10 +76,13 @@ fn run_app(
 
     // Start git polling thread
     let git_active = Arc::new(AtomicBool::new(false));
-    let (git_rx, git_shutdown, _git_handle) = git::start_git_poll_thread(git_active.clone());
+    let (git_rx, git_path_tx, git_shutdown, _git_handle) =
+        git::start_git_poll_thread(git_active.clone());
 
     // Initial refresh
-    state.refresh();
+    if let Some(path) = state.refresh() {
+        let _ = git_path_tx.send(path);
+    }
 
     let mut last_refresh = Instant::now();
     let mut last_spinner = Instant::now();
@@ -128,13 +131,17 @@ fn run_app(
                         // Filter navigation (when filter is focused)
                         (KeyCode::Char('h') | KeyCode::Left, _) if state.focus == Focus::Filter => {
                             state.agent_filter = state.agent_filter.prev();
-                            state.refresh();
+                            if let Some(path) = state.refresh_local_views() {
+                                let _ = git_path_tx.send(path);
+                            }
                         }
                         (KeyCode::Char('l') | KeyCode::Right, _)
                             if state.focus == Focus::Filter =>
                         {
                             state.agent_filter = state.agent_filter.next();
-                            state.refresh();
+                            if let Some(path) = state.refresh_local_views() {
+                                let _ = git_path_tx.send(path);
+                            }
                         }
 
                         // Agent list navigation
@@ -157,7 +164,9 @@ fn run_app(
                                     state.repo_filter = RepoFilter::Repo(name.clone());
                                 }
                                 state.repo_popup_open = false;
-                                state.refresh();
+                                if let Some(path) = state.refresh_local_views() {
+                                    let _ = git_path_tx.send(path);
+                                }
                             } else {
                                 state.jump_to_selected();
                             }
@@ -188,7 +197,9 @@ fn run_app(
                                 state.repo_popup_open = false;
                             } else if state.repo_filter != RepoFilter::All {
                                 state.repo_filter = RepoFilter::All;
-                                state.refresh();
+                                if let Some(path) = state.refresh_local_views() {
+                                    let _ = git_path_tx.send(path);
+                                }
                             }
                         }
 
@@ -250,7 +261,9 @@ fn run_app(
 
         // Periodic refresh
         if last_refresh.elapsed() >= REFRESH_INTERVAL {
-            state.refresh();
+            if let Some(path) = state.refresh() {
+                let _ = git_path_tx.send(path);
+            }
             last_refresh = Instant::now();
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
-use crate::activity::{self, ActivityEntry, TaskProgress};
+use crate::activity::{self, ActivityEntry, ActivitySnapshot, LogFingerprint, TaskProgress};
 use crate::git::GitData;
-use crate::group::{self, RepoGroup};
+use crate::group::{self, PaneGitInfo, RepoGroup};
 use crate::ui::colors::ColorTheme;
 use crate::wezterm::{self, AgentType, PaneInfo, PaneStatus, WorkspaceInfo};
 use std::collections::{HashMap, HashSet};
@@ -156,6 +156,9 @@ pub struct AppState {
     pub pane_task_progress: HashMap<u64, TaskProgress>,
     pub pane_task_dismissed: HashMap<u64, usize>,
     pub pane_inactive_since: HashMap<u64, u64>,
+    pub activity_cache: HashMap<u64, CachedActivity>,
+    pub git_info_cache: HashMap<String, PaneGitInfo>,
+    pub last_git_path: Option<String>,
 
     // Agent tracking
     pub seen_agent_panes: HashSet<u64>,
@@ -168,6 +171,18 @@ pub struct AppState {
     pub repo_popup_selected: usize,
     pub repo_popup_area: Option<ratatui::layout::Rect>,
     pub repo_button_col: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedActivity {
+    pub fingerprint: LogFingerprint,
+    pub snapshot: ActivitySnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivityCachePolicy {
+    RefreshIfChanged,
+    ReuseCached,
 }
 
 impl AppState {
@@ -196,6 +211,9 @@ impl AppState {
             pane_task_progress: HashMap::new(),
             pane_task_dismissed: HashMap::new(),
             pane_inactive_since: HashMap::new(),
+            activity_cache: HashMap::new(),
+            git_info_cache: HashMap::new(),
+            last_git_path: None,
             seen_agent_panes: HashSet::new(),
             pane_tab_prefs: HashMap::new(),
             agent_filter: AgentFilter::All,
@@ -208,13 +226,24 @@ impl AppState {
     }
 
     /// Refresh state from WezTerm.
-    pub fn refresh(&mut self) {
+    pub fn refresh(&mut self) -> Option<String> {
         self.now = current_epoch();
 
-        // Query all workspaces
+        self.refresh_wezterm_snapshot();
+        self.refresh_repo_groups();
+
+        self.refresh_local_views_with_policy(ActivityCachePolicy::RefreshIfChanged)
+    }
+
+    /// Refresh only derived UI state after local filter changes.
+    pub fn refresh_local_views(&mut self) -> Option<String> {
+        self.now = current_epoch();
+        self.refresh_local_views_with_policy(ActivityCachePolicy::ReuseCached)
+    }
+
+    fn refresh_wezterm_snapshot(&mut self) {
         self.workspaces = wezterm::query_workspaces(Some(self.dashboard_pane_id));
 
-        // Find focused pane
         let new_focused = wezterm::find_focused_pane(&self.workspaces, self.dashboard_pane_id);
         if let Some(fid) = new_focused
             && self.focused_pane_id != Some(fid)
@@ -222,21 +251,28 @@ impl AppState {
             self.prev_focused_pane_id = self.focused_pane_id;
             self.focused_pane_id = Some(fid);
         }
+    }
 
-        // Group panes by repo
-        self.repo_groups = group::group_panes_by_repo(&self.workspaces, self.focused_pane_id);
+    fn refresh_repo_groups(&mut self) {
+        self.repo_groups = group::group_panes_by_repo(
+            &self.workspaces,
+            self.focused_pane_id,
+            &mut self.git_info_cache,
+        );
+        self.prune_git_cache();
+    }
 
-        // Rebuild row targets
-        self.rebuild_row_targets();
-
-        // Refresh activity log for focused pane
-        self.refresh_activity();
-
-        // Refresh task progress
-        self.refresh_task_progress();
-
-        // Write focused pane path for git thread
-        self.write_git_path();
+    fn prune_git_cache(&mut self) {
+        let mut active_paths = HashSet::new();
+        for ws in &self.workspaces {
+            for tab in &ws.tabs {
+                for pane in &tab.panes {
+                    active_paths.insert(pane.path.clone());
+                }
+            }
+        }
+        self.git_info_cache
+            .retain(|path, _| active_paths.contains(path));
     }
 
     /// Rebuild the flat list of selectable agent rows from groups.
@@ -280,50 +316,102 @@ impl AppState {
         }
     }
 
-    fn refresh_activity(&mut self) {
-        if let Some(pane_id) = self.focused_pane_id {
-            self.activity_entries = activity::read_activity_log(pane_id, self.activity_max_entries);
-        } else if let Some(first) = self.agent_row_targets.first() {
-            self.activity_entries =
-                activity::read_activity_log(first.pane_id, self.activity_max_entries);
-        } else {
-            self.activity_entries.clear();
-        }
+    fn refresh_local_views_with_policy(
+        &mut self,
+        activity_cache_policy: ActivityCachePolicy,
+    ) -> Option<String> {
+        self.rebuild_row_targets();
+        self.refresh_activity_cache(activity_cache_policy);
+        self.refresh_activity_view();
+        self.refresh_git_target()
     }
 
-    fn refresh_task_progress(&mut self) {
-        let mut active_panes = HashSet::new();
+    fn tracked_activity_panes(&self) -> HashSet<u64> {
+        let mut tracked_panes: HashSet<u64> = self
+            .agent_row_targets
+            .iter()
+            .map(|target| target.pane_id)
+            .collect();
 
+        if let Some(pane_id) = self.focused_pane_id {
+            tracked_panes.insert(pane_id);
+        }
+
+        tracked_panes
+    }
+
+    fn refresh_activity_cache(&mut self, policy: ActivityCachePolicy) {
+        let tracked_panes = self.tracked_activity_panes();
+
+        for pane_id in &tracked_panes {
+            let fingerprint = match policy {
+                ActivityCachePolicy::RefreshIfChanged => Some(activity::log_fingerprint(*pane_id)),
+                ActivityCachePolicy::ReuseCached => None,
+            };
+
+            let should_refresh = match (self.activity_cache.get(pane_id), fingerprint.as_ref()) {
+                (None, _) => true,
+                (Some(_), None) => false,
+                (Some(cached), Some(fingerprint)) => cached.fingerprint != *fingerprint,
+            };
+
+            if should_refresh {
+                let fingerprint =
+                    fingerprint.unwrap_or_else(|| activity::log_fingerprint(*pane_id));
+                let snapshot =
+                    activity::read_activity_snapshot(*pane_id, self.activity_max_entries, 100);
+                self.activity_cache.insert(
+                    *pane_id,
+                    CachedActivity {
+                        fingerprint,
+                        snapshot,
+                    },
+                );
+            }
+        }
+
+        self.activity_cache
+            .retain(|id, _| tracked_panes.contains(id));
+    }
+
+    fn refresh_activity_view(&mut self) {
+        let activity_pane_id = self
+            .focused_pane_id
+            .or_else(|| self.agent_row_targets.first().map(|target| target.pane_id));
+
+        self.activity_entries = activity_pane_id
+            .and_then(|pane_id| self.activity_cache.get(&pane_id))
+            .map(|cached| cached.snapshot.display_entries.clone())
+            .unwrap_or_default();
+
+        self.pane_task_progress.clear();
         for target in &self.agent_row_targets {
-            active_panes.insert(target.pane_id);
+            let Some(cached) = self.activity_cache.get(&target.pane_id) else {
+                continue;
+            };
 
-            let entries = activity::read_activity_log(target.pane_id, 100);
-            let progress = activity::parse_task_progress(&entries);
-
-            if progress.is_empty() {
-                self.pane_task_progress.remove(&target.pane_id);
-            } else {
-                self.pane_task_progress.insert(target.pane_id, progress);
+            if !cached.snapshot.task_progress.is_empty() {
+                self.pane_task_progress
+                    .insert(target.pane_id, cached.snapshot.task_progress.clone());
             }
         }
-
-        // Clean up stale entries
-        self.pane_task_progress
-            .retain(|id, _| active_panes.contains(id));
     }
 
-    fn write_git_path(&self) {
-        if let Some(pane_id) = self.focused_pane_id {
-            // Find the focused pane's path
-            for group in &self.repo_groups {
-                for (pane, _) in &group.panes {
-                    if pane.pane_id == pane_id {
-                        let _ = std::fs::write("/tmp/wezterm-agent-dashboard-git-path", &pane.path);
-                        return;
-                    }
-                }
-            }
+    fn refresh_git_target(&mut self) -> Option<String> {
+        let path = self.focused_pane_id.and_then(|pane_id| {
+            self.repo_groups
+                .iter()
+                .flat_map(|group| group.panes.iter())
+                .find(|(pane, _)| pane.pane_id == pane_id)
+                .map(|(pane, _)| pane.path.clone())
+        });
+
+        if path != self.last_git_path {
+            self.last_git_path = path.clone();
+            return path;
         }
+
+        None
     }
 
     /// Count agents by status, respecting current repo filter.
@@ -433,11 +521,31 @@ mod tests {
         }
     }
 
+    fn make_pane_with_path(pane_id: u64, status: PaneStatus, path: &str) -> PaneInfo {
+        let mut pane = make_pane(pane_id, status);
+        pane.path = path.into();
+        pane
+    }
+
     fn make_git_info() -> PaneGitInfo {
         PaneGitInfo {
             repo_root: Some("/tmp/test".into()),
             branch: Some("main".into()),
             is_worktree: false,
+        }
+    }
+
+    fn make_cached_activity(label: &str, progress: TaskProgress) -> CachedActivity {
+        CachedActivity {
+            fingerprint: LogFingerprint::missing(),
+            snapshot: ActivitySnapshot {
+                display_entries: vec![ActivityEntry {
+                    timestamp: "14:32".into(),
+                    tool: "Bash".into(),
+                    label: label.into(),
+                }],
+                task_progress: progress,
+            },
         }
     }
 
@@ -707,5 +815,76 @@ mod tests {
         ];
         let state = make_state_with_groups(groups);
         assert_eq!(state.repo_names(), vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_refresh_local_views_updates_filters_without_snapshot_refresh() {
+        let pane1 = make_pane_with_path(1, PaneStatus::Running, "/repo-a");
+        let pane2 = make_pane_with_path(2, PaneStatus::Idle, "/repo-b");
+        let mut state = AppState::new(999);
+        state.repo_groups = vec![
+            RepoGroup {
+                name: "repo-a".into(),
+                has_focus: true,
+                panes: vec![(
+                    pane1.clone(),
+                    PaneGitInfo {
+                        repo_root: Some("/repo-a".into()),
+                        branch: Some("main".into()),
+                        is_worktree: false,
+                    },
+                )],
+            },
+            RepoGroup {
+                name: "repo-b".into(),
+                has_focus: false,
+                panes: vec![(
+                    pane2.clone(),
+                    PaneGitInfo {
+                        repo_root: Some("/repo-b".into()),
+                        branch: Some("main".into()),
+                        is_worktree: false,
+                    },
+                )],
+            },
+        ];
+        state.focused_pane_id = Some(1);
+        state.activity_cache.insert(
+            1,
+            make_cached_activity(
+                "focused activity",
+                TaskProgress {
+                    tasks: vec![("1".into(), activity::TaskStatus::InProgress)],
+                },
+            ),
+        );
+        state.activity_cache.insert(
+            2,
+            make_cached_activity(
+                "other activity",
+                TaskProgress {
+                    tasks: vec![("2".into(), activity::TaskStatus::Completed)],
+                },
+            ),
+        );
+
+        let git_path = state.refresh_local_views();
+        assert_eq!(git_path.as_deref(), Some("/repo-a"));
+        assert_eq!(state.agent_row_targets.len(), 2);
+        assert_eq!(state.activity_entries.len(), 1);
+        assert_eq!(state.activity_entries[0].label, "focused activity");
+        assert_eq!(state.pane_task_progress.len(), 2);
+
+        state.repo_filter = RepoFilter::Repo("repo-b".into());
+
+        let git_path = state.refresh_local_views();
+        assert_eq!(git_path, None);
+        assert_eq!(state.agent_row_targets.len(), 1);
+        assert_eq!(state.agent_row_targets[0].pane_id, 2);
+        assert_eq!(state.activity_entries[0].label, "focused activity");
+        assert_eq!(state.pane_task_progress.len(), 1);
+        assert!(state.pane_task_progress.contains_key(&2));
+        assert!(state.activity_cache.contains_key(&1));
+        assert!(state.activity_cache.contains_key(&2));
     }
 }


### PR DESCRIPTION
## Summary
Split the refresh pipeline so synchronous I/O is no longer concentrated in a single refresh path.

## What Changed
- separated `AppState` refresh into full snapshot refresh and local derived-view refresh paths
- reused cached activity snapshots when only local filters change, while still fingerprinting logs on full refresh
- reused repo-level git resolution for pane paths under the same repository root
- kept git polling on a channel-based focused path update instead of `/tmp` file handoff
- added tests around local refresh behavior and git-info cache reuse

## Why
Issue #11 points out that the old refresh path stacked multiple synchronous operations every second. This change preserves behavior while reducing repeated work from filter interactions and pane path git resolution.

## Impact
- fewer `wezterm cli list` calls during local UI filter changes
- less repeated activity log parsing when nothing changed
- less repeated `git rev-parse` work for panes in the same repo tree

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features` (remaining warning is the pre-existing `src/user_vars.rs` needless borrow in tests)

Closes #11