### PR TITLE
Git更新のキャッシュ化とCIテスト分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  test:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -23,6 +23,50 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - run: cargo fmt -- --check
-      - run: cargo clippy -- -D warnings
-      - run: cargo test
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: cargo test -- --skip integration_tests::
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: cargo test integration_tests::
+
+  build:
+    needs: [quality, test-unit, test-integration]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - run: cargo build --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  verify:
+  verify-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -25,8 +25,56 @@ jobs:
             exit 1
           fi
 
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: cargo fmt -- --check
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: cargo test -- --skip integration_tests::
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: cargo test integration_tests::
+
   build:
-    needs: verify
+    needs: [verify-version, quality, test-unit, test-integration]
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +352,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +394,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -604,6 +634,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +718,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "time",
  "unicode-width 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ indexmap = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
+time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 
 [dev-dependencies]
 indoc = "2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,26 +48,17 @@ pub fn json_str<'a>(value: &'a serde_json::Value, key: &str) -> &'a str {
 
 /// Get local time as HH:MM string.
 pub fn local_time_hhmm() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    let format = time::macros::format_description!("[hour]:[minute]");
 
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Get local timezone offset using libc-free approach
-    // We parse the output of `date +%H:%M` for simplicity and portability
-    if let Ok(output) = std::process::Command::new("date").arg("+%H:%M").output()
-        && output.status.success()
+    if let Ok(now) = time::OffsetDateTime::now_local()
+        && let Ok(formatted) = now.format(&format)
     {
-        let s = String::from_utf8_lossy(&output.stdout);
-        return s.trim().to_string();
+        return formatted;
     }
 
-    // Fallback: UTC
-    let hours = (secs / 3600) % 24;
-    let minutes = (secs / 60) % 60;
-    format!("{hours:02}:{minutes:02}")
+    time::OffsetDateTime::now_utc()
+        .format(&format)
+        .unwrap_or_else(|_| "00:00".to_string())
 }
 
 /// Sanitize a string value for storage: replace newlines and pipes with spaces.

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,13 +3,26 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+const GIT_LOOP_INTERVAL: Duration = Duration::from_millis(250);
+const GIT_SUMMARY_TTL: Duration = Duration::from_secs(2);
+const GIT_PR_TTL: Duration = Duration::from_secs(30);
+const GIT_PR_LAZY_DELAY: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Clone, Copy)]
+struct GitPollConfig {
+    loop_interval: Duration,
+    summary_ttl: Duration,
+    pr_ttl: Duration,
+    pr_lazy_delay: Duration,
+}
 
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GitData {
     pub branch: String,
     pub ahead: u32,
@@ -26,11 +39,18 @@ pub struct GitData {
     pub path: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitFileStatus {
     pub file: String,
     pub insertions: u32,
     pub deletions: u32,
+}
+
+#[derive(Debug, Clone)]
+struct CachedGitData {
+    data: GitData,
+    summary_fetched_at: Option<Instant>,
+    pr_fetched_at: Option<Instant>,
 }
 
 // ---------------------------------------------------------------------------
@@ -39,6 +59,12 @@ pub struct GitFileStatus {
 
 /// Fetch all git data for a given working directory.
 pub fn fetch_git_data(cwd: &str) -> GitData {
+    let mut data = fetch_git_summary(cwd);
+    data.pr_number = fetch_pr_number(cwd);
+    data
+}
+
+fn fetch_git_summary(cwd: &str) -> GitData {
     if cwd.is_empty() {
         return GitData::default();
     }
@@ -122,9 +148,6 @@ pub fn fetch_git_data(cwd: &str) -> GitData {
         data.remote_url = normalize_remote_url(&url);
     }
 
-    // PR number (with timeout)
-    data.pr_number = fetch_pr_number(cwd);
-
     data
 }
 
@@ -148,6 +171,12 @@ fn parse_numstat(
     total_ins: &mut u32,
     total_del: &mut u32,
 ) {
+    let file_indexes: std::collections::HashMap<String, usize> = files
+        .iter()
+        .enumerate()
+        .map(|(idx, file)| (file.file.clone(), idx))
+        .collect();
+
     for line in numstat.lines() {
         let parts: Vec<&str> = line.split('\t').collect();
         if parts.len() >= 3 {
@@ -158,7 +187,8 @@ fn parse_numstat(
             *total_ins += ins;
             *total_del += del;
 
-            if let Some(f) = files.iter_mut().find(|f| f.file == file) {
+            if let Some(idx) = file_indexes.get(file) {
+                let f = &mut files[*idx];
                 f.insertions = ins;
                 f.deletions = del;
             }
@@ -190,6 +220,29 @@ fn fetch_pr_number(cwd: &str) -> Option<u32> {
     stdout.trim().parse::<u32>().ok()
 }
 
+impl CachedGitData {
+    fn new(path: &str) -> Self {
+        Self {
+            data: GitData {
+                path: path.to_string(),
+                ..Default::default()
+            },
+            summary_fetched_at: None,
+            pr_fetched_at: None,
+        }
+    }
+
+    fn summary_is_fresh(&self, now: Instant, ttl: Duration) -> bool {
+        self.summary_fetched_at
+            .is_some_and(|fetched_at| now.duration_since(fetched_at) < ttl)
+    }
+
+    fn pr_is_fresh(&self, now: Instant, ttl: Duration) -> bool {
+        self.pr_fetched_at
+            .is_some_and(|fetched_at| now.duration_since(fetched_at) < ttl)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Background polling thread
 // ---------------------------------------------------------------------------
@@ -210,35 +263,141 @@ pub fn start_git_poll_thread(
     let shutdown_clone = shutdown.clone();
 
     let handle = thread::spawn(move || {
-        let mut current_path = String::new();
-
-        loop {
-            if shutdown_clone.load(Ordering::Relaxed) {
-                break;
-            }
-
-            while let Ok(path) = path_rx.try_recv() {
-                current_path = path;
-            }
-
-            thread::sleep(Duration::from_secs(2));
-
-            if !active.load(Ordering::Relaxed) {
-                continue;
-            }
-
-            if current_path.is_empty() {
-                continue;
-            }
-
-            let data = fetch_git_data(&current_path);
-            if tx.send(data).is_err() {
-                break;
-            }
-        }
+        run_git_poll_loop(
+            active,
+            path_rx,
+            tx,
+            shutdown_clone,
+            GitPollConfig {
+                loop_interval: GIT_LOOP_INTERVAL,
+                summary_ttl: GIT_SUMMARY_TTL,
+                pr_ttl: GIT_PR_TTL,
+                pr_lazy_delay: GIT_PR_LAZY_DELAY,
+            },
+            fetch_git_summary,
+            fetch_pr_number,
+        );
     });
 
     (rx, path_tx, shutdown, handle)
+}
+
+fn run_git_poll_loop<FS, FP>(
+    active: Arc<AtomicBool>,
+    path_rx: mpsc::Receiver<String>,
+    tx: mpsc::Sender<GitData>,
+    shutdown: Arc<AtomicBool>,
+    config: GitPollConfig,
+    mut fetch_summary: FS,
+    mut fetch_pr: FP,
+) where
+    FS: FnMut(&str) -> GitData,
+    FP: FnMut(&str) -> Option<u32>,
+{
+    let mut current_path = String::new();
+    let mut current_path_since = Instant::now();
+    let mut cache = std::collections::HashMap::new();
+    let mut last_sent: Option<GitData> = None;
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+
+        while let Ok(path) = path_rx.try_recv() {
+            if current_path != path {
+                current_path = path;
+                current_path_since = Instant::now();
+                last_sent = None;
+            }
+        }
+
+        if !active.load(Ordering::Relaxed) {
+            thread::sleep(config.loop_interval);
+            continue;
+        }
+
+        let data = current_git_data_with(
+            &mut cache,
+            &current_path,
+            current_path_since,
+            Instant::now(),
+            config,
+            &mut fetch_summary,
+            &mut fetch_pr,
+        );
+        if last_sent.as_ref() != Some(&data) && tx.send(data.clone()).is_err() {
+            break;
+        }
+        last_sent = Some(data);
+
+        thread::sleep(config.loop_interval);
+    }
+}
+
+fn current_git_data_with<FS, FP>(
+    cache: &mut std::collections::HashMap<String, CachedGitData>,
+    path: &str,
+    path_selected_at: Instant,
+    now: Instant,
+    config: GitPollConfig,
+    fetch_summary: &mut FS,
+    fetch_pr: &mut FP,
+) -> GitData
+where
+    FS: FnMut(&str) -> GitData,
+    FP: FnMut(&str) -> Option<u32>,
+{
+    if path.is_empty() {
+        return GitData::default();
+    }
+
+    let entry = cache
+        .entry(path.to_string())
+        .or_insert_with(|| CachedGitData::new(path));
+
+    if !entry.summary_is_fresh(now, config.summary_ttl) {
+        let cached_pr = if entry.pr_is_fresh(now, config.pr_ttl) {
+            entry.data.pr_number
+        } else {
+            None
+        };
+
+        entry.data = fetch_summary(path);
+        entry.data.pr_number = cached_pr;
+        entry.summary_fetched_at = Some(now);
+    }
+
+    if should_fetch_pr(
+        entry,
+        now,
+        path_selected_at,
+        config.pr_ttl,
+        config.pr_lazy_delay,
+    ) {
+        entry.data.pr_number = fetch_pr(path);
+        entry.pr_fetched_at = Some(now);
+    }
+
+    entry.data.clone()
+}
+
+fn should_fetch_pr(
+    entry: &CachedGitData,
+    now: Instant,
+    path_selected_at: Instant,
+    pr_ttl: Duration,
+    pr_lazy_delay: Duration,
+) -> bool {
+    if entry.pr_is_fresh(now, pr_ttl) {
+        return false;
+    }
+
+    if now.duration_since(path_selected_at) < pr_lazy_delay {
+        return false;
+    }
+
+    !entry.data.branch.is_empty() && !entry.data.remote_url.is_empty()
 }
 
 // ---------------------------------------------------------------------------
@@ -379,5 +538,211 @@ mod tests {
         let data = fetch_git_data("");
         assert!(data.branch.is_empty());
         assert!(data.path.is_empty());
+    }
+
+    #[test]
+    fn test_should_fetch_pr_waits_for_lazy_delay() {
+        let now = Instant::now();
+        let entry = CachedGitData {
+            data: GitData {
+                branch: "main".into(),
+                remote_url: "https://github.com/user/repo".into(),
+                ..Default::default()
+            },
+            summary_fetched_at: Some(now),
+            pr_fetched_at: None,
+        };
+
+        assert!(!should_fetch_pr(
+            &entry,
+            now,
+            now,
+            GIT_PR_TTL,
+            GIT_PR_LAZY_DELAY
+        ));
+        assert!(should_fetch_pr(
+            &entry,
+            now + GIT_PR_LAZY_DELAY,
+            now,
+            GIT_PR_TTL,
+            GIT_PR_LAZY_DELAY
+        ));
+    }
+
+    #[test]
+    fn test_should_fetch_pr_respects_fresh_cache() {
+        let now = Instant::now();
+        let entry = CachedGitData {
+            data: GitData {
+                branch: "main".into(),
+                remote_url: "https://github.com/user/repo".into(),
+                pr_number: Some(123),
+                ..Default::default()
+            },
+            summary_fetched_at: Some(now),
+            pr_fetched_at: Some(now),
+        };
+
+        assert!(!should_fetch_pr(
+            &entry,
+            now + Duration::from_secs(1),
+            now - GIT_PR_LAZY_DELAY,
+            GIT_PR_TTL,
+            GIT_PR_LAZY_DELAY
+        ));
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    #[test]
+    fn test_git_worker_waits_until_active() {
+        let (tx, rx) = mpsc::channel();
+        let (path_tx, path_rx) = mpsc::channel();
+        let active = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        path_tx.send("/repo".into()).unwrap();
+
+        let active_clone = active.clone();
+        let shutdown_clone = shutdown.clone();
+        let handle = thread::spawn(move || {
+            run_git_poll_loop(
+                active_clone,
+                path_rx,
+                tx,
+                shutdown_clone,
+                GitPollConfig {
+                    loop_interval: Duration::from_millis(5),
+                    summary_ttl: Duration::from_secs(60),
+                    pr_ttl: Duration::from_secs(60),
+                    pr_lazy_delay: Duration::from_secs(60),
+                },
+                |path| GitData {
+                    branch: "main".into(),
+                    path: path.into(),
+                    ..Default::default()
+                },
+                |_| None,
+            );
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(40)).is_err());
+        active.store(true, Ordering::Relaxed);
+
+        let data = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        assert_eq!(data.path, "/repo");
+        assert_eq!(data.branch, "main");
+    }
+
+    #[test]
+    fn test_git_worker_uses_latest_queued_path() {
+        let (tx, rx) = mpsc::channel();
+        let (path_tx, path_rx) = mpsc::channel();
+        let active = Arc::new(AtomicBool::new(true));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let seen_paths = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        path_tx.send("/repo-old".into()).unwrap();
+        path_tx.send("/repo-new".into()).unwrap();
+
+        let active_clone = active.clone();
+        let shutdown_clone = shutdown.clone();
+        let seen_paths_clone = seen_paths.clone();
+        let handle = thread::spawn(move || {
+            run_git_poll_loop(
+                active_clone,
+                path_rx,
+                tx,
+                shutdown_clone,
+                GitPollConfig {
+                    loop_interval: Duration::from_millis(5),
+                    summary_ttl: Duration::from_secs(60),
+                    pr_ttl: Duration::from_secs(60),
+                    pr_lazy_delay: Duration::from_secs(60),
+                },
+                move |path| {
+                    seen_paths_clone.lock().unwrap().push(path.to_string());
+                    GitData {
+                        branch: "main".into(),
+                        path: path.into(),
+                        ..Default::default()
+                    }
+                },
+                |_| None,
+            );
+        });
+
+        let data = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        assert_eq!(data.path, "/repo-new");
+        assert_eq!(*seen_paths.lock().unwrap(), vec!["/repo-new".to_string()]);
+    }
+
+    #[test]
+    fn test_git_worker_emits_summary_then_lazy_pr_update() {
+        let (tx, rx) = mpsc::channel();
+        let (path_tx, path_rx) = mpsc::channel();
+        let active = Arc::new(AtomicBool::new(true));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let summary_calls = Arc::new(AtomicUsize::new(0));
+        let pr_calls = Arc::new(AtomicUsize::new(0));
+
+        path_tx.send("/repo".into()).unwrap();
+
+        let active_clone = active.clone();
+        let shutdown_clone = shutdown.clone();
+        let summary_calls_clone = summary_calls.clone();
+        let pr_calls_clone = pr_calls.clone();
+        let handle = thread::spawn(move || {
+            run_git_poll_loop(
+                active_clone,
+                path_rx,
+                tx,
+                shutdown_clone,
+                GitPollConfig {
+                    loop_interval: Duration::from_millis(5),
+                    summary_ttl: Duration::from_secs(60),
+                    pr_ttl: Duration::from_secs(60),
+                    pr_lazy_delay: Duration::from_millis(30),
+                },
+                move |path| {
+                    summary_calls_clone.fetch_add(1, AtomicOrdering::Relaxed);
+                    GitData {
+                        branch: "main".into(),
+                        remote_url: "https://github.com/user/repo".into(),
+                        path: path.into(),
+                        ..Default::default()
+                    }
+                },
+                move |_| {
+                    pr_calls_clone.fetch_add(1, AtomicOrdering::Relaxed);
+                    Some(42)
+                },
+            );
+        });
+
+        let first = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        let second = rx.recv_timeout(Duration::from_millis(150)).unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        assert_eq!(first.path, "/repo");
+        assert_eq!(first.pr_number, None);
+        assert_eq!(second.path, "/repo");
+        assert_eq!(second.pr_number, Some(42));
+        assert_eq!(summary_calls.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(pr_calls.load(AtomicOrdering::Relaxed), 1);
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,14 +1,19 @@
 use crate::wezterm::{PaneInfo, WorkspaceInfo};
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PaneGitInfo {
     pub repo_root: Option<String>,
     pub branch: Option<String>,
@@ -21,6 +26,12 @@ pub struct RepoGroup {
     pub name: String,
     pub has_focus: bool,
     pub panes: Vec<(PaneInfo, PaneGitInfo)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoInfoUpdate {
+    pub path: String,
+    pub info: PaneGitInfo,
 }
 
 // ---------------------------------------------------------------------------
@@ -100,7 +111,7 @@ pub fn resolve_pane_git_info(path: &str) -> PaneGitInfo {
     }
 }
 
-fn cached_git_info_for_path(
+pub fn lookup_cached_git_info_for_path(
     path: &str,
     git_cache: &HashMap<String, PaneGitInfo>,
 ) -> Option<PaneGitInfo> {
@@ -125,18 +136,89 @@ fn cached_git_info_for_path(
         .map(|(_, info)| info)
 }
 
-fn resolve_cached_git_info(
-    path: &str,
-    git_cache: &mut HashMap<String, PaneGitInfo>,
-) -> PaneGitInfo {
-    if let Some(info) = cached_git_info_for_path(path, git_cache) {
-        git_cache.insert(path.to_string(), info.clone());
-        return info;
-    }
+pub fn start_repo_poll_thread() -> (
+    mpsc::Receiver<RepoInfoUpdate>,
+    mpsc::Sender<String>,
+    Arc<AtomicBool>,
+    thread::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::channel();
+    let (path_tx, path_rx) = mpsc::channel::<String>();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
 
-    let info = resolve_pane_git_info(path);
-    git_cache.insert(path.to_string(), info.clone());
-    info
+    let handle = thread::spawn(move || {
+        run_repo_poll_loop(
+            tx,
+            path_rx,
+            shutdown_clone,
+            Duration::from_millis(50),
+            resolve_pane_git_info,
+        );
+    });
+
+    (rx, path_tx, shutdown, handle)
+}
+
+fn run_repo_poll_loop<F>(
+    tx: mpsc::Sender<RepoInfoUpdate>,
+    path_rx: mpsc::Receiver<String>,
+    shutdown: Arc<AtomicBool>,
+    idle_sleep: Duration,
+    mut resolve: F,
+) where
+    F: FnMut(&str) -> PaneGitInfo,
+{
+    let mut cache = HashMap::new();
+    let mut queued_paths = VecDeque::new();
+    let mut queued_set = HashSet::new();
+    let mut release_after_drain: Option<String> = None;
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+
+        while let Ok(path) = path_rx.try_recv() {
+            if queued_set.insert(path.clone()) {
+                queued_paths.push_back(path);
+            }
+        }
+
+        if let Some(path) = release_after_drain.take() {
+            queued_set.remove(&path);
+        }
+
+        let Some(path) = queued_paths.pop_front() else {
+            thread::sleep(idle_sleep);
+            continue;
+        };
+
+        let info = if let Some(info) = lookup_cached_git_info_for_path(&path, &cache) {
+            info
+        } else {
+            resolve(&path)
+        };
+
+        cache.insert(path.clone(), info.clone());
+        if let Some(repo_root) = info.repo_root.as_ref() {
+            cache
+                .entry(repo_root.clone())
+                .or_insert_with(|| info.clone());
+        }
+
+        if tx
+            .send(RepoInfoUpdate {
+                path: path.clone(),
+                info,
+            })
+            .is_err()
+        {
+            break;
+        }
+
+        release_after_drain = Some(path);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +230,7 @@ fn resolve_cached_git_info(
 pub fn group_panes_by_repo(
     workspaces: &[WorkspaceInfo],
     focused_pane_id: Option<u64>,
-    git_cache: &mut HashMap<String, PaneGitInfo>,
+    git_cache: &HashMap<String, PaneGitInfo>,
 ) -> Vec<RepoGroup> {
     // group_key → Vec<(PaneInfo, PaneGitInfo)>
     let mut groups: IndexMap<String, Vec<(PaneInfo, PaneGitInfo)>> = IndexMap::new();
@@ -156,7 +238,8 @@ pub fn group_panes_by_repo(
     for ws in workspaces {
         for tab in &ws.tabs {
             for pane in &tab.panes {
-                let git_info = resolve_cached_git_info(&pane.path, git_cache);
+                let git_info =
+                    lookup_cached_git_info_for_path(&pane.path, git_cache).unwrap_or_default();
 
                 let group_key = git_info
                     .repo_root
@@ -317,10 +400,9 @@ mod grouping_tests {
         let mut cache = HashMap::new();
         cache.insert("/repo".into(), make_git_info("/repo"));
 
-        let info = resolve_cached_git_info("/repo/src/module", &mut cache);
+        let info = lookup_cached_git_info_for_path("/repo/src/module", &cache).unwrap();
 
         assert_eq!(info.repo_root.as_deref(), Some("/repo"));
-        assert!(cache.contains_key("/repo/src/module"));
     }
 
     #[test]
@@ -329,7 +411,7 @@ mod grouping_tests {
         let mut cache = HashMap::new();
         cache.insert("/repo".into(), make_git_info("/repo"));
 
-        let groups = group_panes_by_repo(&workspaces, Some(2), &mut cache);
+        let groups = group_panes_by_repo(&workspaces, Some(2), &cache);
 
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].name, "repo");
@@ -337,6 +419,93 @@ mod grouping_tests {
         assert_eq!(groups[0].panes.len(), 2);
         assert_eq!(groups[0].panes[0].1.repo_root.as_deref(), Some("/repo"));
         assert_eq!(groups[0].panes[1].1.repo_root.as_deref(), Some("/repo"));
-        assert!(cache.contains_key("/repo/src"));
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    fn make_git_info(repo_root: &str) -> PaneGitInfo {
+        PaneGitInfo {
+            repo_root: Some(repo_root.into()),
+            branch: Some("main".into()),
+            is_worktree: false,
+        }
+    }
+
+    #[test]
+    fn test_repo_worker_reuses_cached_repo_info_for_subdirs() {
+        use std::sync::atomic::AtomicUsize;
+
+        let (tx, rx) = mpsc::channel();
+        let (path_tx, path_rx) = mpsc::channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let shutdown_clone = shutdown.clone();
+        let calls_clone = calls.clone();
+        let handle = thread::spawn(move || {
+            run_repo_poll_loop(
+                tx,
+                path_rx,
+                shutdown_clone,
+                Duration::from_millis(1),
+                move |_| {
+                    calls_clone.fetch_add(1, Ordering::Relaxed);
+                    make_git_info("/repo")
+                },
+            );
+        });
+
+        path_tx.send("/repo".into()).unwrap();
+        let first = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        assert_eq!(first.info.repo_root.as_deref(), Some("/repo"));
+
+        path_tx.send("/repo/src/module".into()).unwrap();
+        let second = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        assert_eq!(second.info.repo_root.as_deref(), Some("/repo"));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_repo_worker_dedupes_inflight_duplicate_paths() {
+        let (tx, rx) = mpsc::channel();
+        let (path_tx, path_rx) = mpsc::channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = mpsc::channel();
+
+        let shutdown_clone = shutdown.clone();
+        let handle = thread::spawn(move || {
+            run_repo_poll_loop(
+                tx,
+                path_rx,
+                shutdown_clone,
+                Duration::from_millis(1),
+                move |_| {
+                    let _ = started_tx.send(());
+                    thread::sleep(Duration::from_millis(40));
+                    make_git_info("/repo")
+                },
+            );
+        });
+
+        path_tx.send("/repo".into()).unwrap();
+        started_rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        path_tx.send("/repo".into()).unwrap();
+
+        let first = rx.recv_timeout(Duration::from_millis(150)).unwrap();
+        let second = rx.recv_timeout(Duration::from_millis(80));
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().unwrap();
+
+        assert_eq!(first.info.repo_root.as_deref(), Some("/repo"));
+        assert!(second.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,11 @@ use ratatui::backend::CrosstermBackend;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
 use wezterm_agent_dashboard::git;
-use wezterm_agent_dashboard::state::{AppState, BottomTab, Focus, RepoFilter};
+use wezterm_agent_dashboard::group;
+use wezterm_agent_dashboard::state::{AppState, BottomTab, Focus, RefreshActions, RepoFilter};
 use wezterm_agent_dashboard::ui::Dashboard;
 use wezterm_agent_dashboard::user_vars;
 
@@ -74,15 +76,16 @@ fn run_app(
 ) -> io::Result<()> {
     let mut state = AppState::new(dashboard_pane_id);
 
+    // Start repo polling thread
+    let (repo_rx, repo_path_tx, repo_shutdown, _repo_handle) = group::start_repo_poll_thread();
+
     // Start git polling thread
     let git_active = Arc::new(AtomicBool::new(false));
     let (git_rx, git_path_tx, git_shutdown, _git_handle) =
         git::start_git_poll_thread(git_active.clone());
 
     // Initial refresh
-    if let Some(path) = state.refresh() {
-        let _ = git_path_tx.send(path);
-    }
+    dispatch_refresh_actions(state.refresh(), &repo_path_tx, &git_path_tx);
 
     let mut last_refresh = Instant::now();
     let mut last_spinner = Instant::now();
@@ -108,6 +111,7 @@ fn run_app(
                     match (key.code, key.modifiers) {
                         // Quit
                         (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                            repo_shutdown.store(true, Ordering::Relaxed);
                             git_shutdown.store(true, Ordering::Relaxed);
                             break;
                         }
@@ -131,17 +135,13 @@ fn run_app(
                         // Filter navigation (when filter is focused)
                         (KeyCode::Char('h') | KeyCode::Left, _) if state.focus == Focus::Filter => {
                             state.agent_filter = state.agent_filter.prev();
-                            if let Some(path) = state.refresh_local_views() {
-                                let _ = git_path_tx.send(path);
-                            }
+                            send_git_path(state.refresh_local_views(), &git_path_tx);
                         }
                         (KeyCode::Char('l') | KeyCode::Right, _)
                             if state.focus == Focus::Filter =>
                         {
                             state.agent_filter = state.agent_filter.next();
-                            if let Some(path) = state.refresh_local_views() {
-                                let _ = git_path_tx.send(path);
-                            }
+                            send_git_path(state.refresh_local_views(), &git_path_tx);
                         }
 
                         // Agent list navigation
@@ -165,9 +165,7 @@ fn run_app(
                                     state.repo_filter = RepoFilter::Repo(id.clone());
                                 }
                                 state.repo_popup_open = false;
-                                if let Some(path) = state.refresh_local_views() {
-                                    let _ = git_path_tx.send(path);
-                                }
+                                send_git_path(state.refresh_local_views(), &git_path_tx);
                             } else {
                                 state.jump_to_selected();
                             }
@@ -198,9 +196,7 @@ fn run_app(
                                 state.repo_popup_open = false;
                             } else if state.repo_filter != RepoFilter::All {
                                 state.repo_filter = RepoFilter::All;
-                                if let Some(path) = state.refresh_local_views() {
-                                    let _ = git_path_tx.send(path);
-                                }
+                                send_git_path(state.refresh_local_views(), &git_path_tx);
                             }
                         }
 
@@ -232,17 +228,50 @@ fn run_app(
 
         // Periodic refresh
         if last_refresh.elapsed() >= REFRESH_INTERVAL {
-            if let Some(path) = state.refresh() {
-                let _ = git_path_tx.send(path);
-            }
+            dispatch_refresh_actions(state.refresh(), &repo_path_tx, &git_path_tx);
             last_refresh = Instant::now();
         }
 
+        // Check for repo data from background thread
+        let mut repo_updates = Vec::new();
+        while let Ok(update) = repo_rx.try_recv() {
+            repo_updates.push(update);
+        }
+        if !repo_updates.is_empty() {
+            dispatch_refresh_actions(
+                state.apply_repo_info_updates(repo_updates),
+                &repo_path_tx,
+                &git_path_tx,
+            );
+        }
+
         // Check for git data from background thread
-        if let Ok(data) = git_rx.try_recv() {
+        let mut latest_git = None;
+        while let Ok(data) = git_rx.try_recv() {
+            latest_git = Some(data);
+        }
+        if let Some(data) = latest_git {
             state.git = data;
         }
     }
 
     Ok(())
+}
+
+fn dispatch_refresh_actions(
+    actions: RefreshActions,
+    repo_path_tx: &Sender<String>,
+    git_path_tx: &Sender<String>,
+) {
+    for path in actions.repo_paths {
+        let _ = repo_path_tx.send(path);
+    }
+
+    send_git_path(actions.git_path, git_path_tx);
+}
+
+fn send_git_path(path: Option<String>, git_path_tx: &Sender<String>) {
+    if let Some(path) = path {
+        let _ = git_path_tx.send(path);
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,10 @@
 use crate::activity::{self, ActivityEntry, ActivitySnapshot, LogFingerprint, TaskProgress};
 use crate::git::GitData;
-use crate::group::{self, PaneGitInfo, RepoGroup};
+use crate::group::{self, PaneGitInfo, RepoGroup, RepoInfoUpdate};
 use crate::ui::colors::ColorTheme;
 use crate::wezterm::{self, AgentType, PaneInfo, PaneStatus, WorkspaceInfo};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 const ACTIVITY_MAX_ENTRIES: usize = 8;
 
@@ -91,6 +92,12 @@ pub struct RowTarget {
     pub agent: AgentType,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RefreshActions {
+    pub git_path: Option<String>,
+    pub repo_paths: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // AppState
 // ---------------------------------------------------------------------------
@@ -123,7 +130,8 @@ pub struct AppState {
     // Task progress
     pub pane_task_progress: HashMap<u64, TaskProgress>,
     pub activity_cache: HashMap<u64, CachedActivity>,
-    pub git_info_cache: HashMap<String, PaneGitInfo>,
+    pub repo_info_cache: HashMap<String, PaneGitInfo>,
+    pub pending_repo_paths: HashSet<String>,
     pub last_git_path: Option<String>,
 
     // Filters
@@ -163,7 +171,8 @@ impl AppState {
             git: GitData::default(),
             pane_task_progress: HashMap::new(),
             activity_cache: HashMap::new(),
-            git_info_cache: HashMap::new(),
+            repo_info_cache: HashMap::new(),
+            pending_repo_paths: HashSet::new(),
             last_git_path: None,
             agent_filter: AgentFilter::All,
             repo_filter: RepoFilter::All,
@@ -173,19 +182,46 @@ impl AppState {
     }
 
     /// Refresh state from WezTerm.
-    pub fn refresh(&mut self) -> Option<String> {
+    pub fn refresh(&mut self) -> RefreshActions {
         self.now = current_epoch();
 
         self.refresh_wezterm_snapshot();
-        self.refresh_repo_groups();
+        let repo_paths = self.refresh_repo_groups();
+        let git_path = self.refresh_local_views_with_policy(ActivityCachePolicy::RefreshIfChanged);
 
-        self.refresh_local_views_with_policy(ActivityCachePolicy::RefreshIfChanged)
+        RefreshActions {
+            git_path,
+            repo_paths,
+        }
     }
 
     /// Refresh only derived UI state after local filter changes.
     pub fn refresh_local_views(&mut self) -> Option<String> {
         self.now = current_epoch();
         self.refresh_local_views_with_policy(ActivityCachePolicy::ReuseCached)
+    }
+
+    pub fn apply_repo_info_updates(&mut self, updates: Vec<RepoInfoUpdate>) -> RefreshActions {
+        if updates.is_empty() {
+            return RefreshActions::default();
+        }
+
+        let mut changed = false;
+        for update in updates {
+            changed |= self.store_repo_info(update.path, update.info);
+        }
+
+        if !changed {
+            return RefreshActions::default();
+        }
+
+        let repo_paths = self.refresh_repo_groups();
+        let git_path = self.refresh_local_views_with_policy(ActivityCachePolicy::ReuseCached);
+
+        RefreshActions {
+            git_path,
+            repo_paths,
+        }
     }
 
     fn refresh_wezterm_snapshot(&mut self) {
@@ -199,16 +235,17 @@ impl AppState {
         }
     }
 
-    fn refresh_repo_groups(&mut self) {
+    fn refresh_repo_groups(&mut self) -> Vec<String> {
         self.repo_groups = group::group_panes_by_repo(
             &self.workspaces,
             self.focused_pane_id,
-            &mut self.git_info_cache,
+            &self.repo_info_cache,
         );
-        self.prune_git_cache();
+        self.prune_repo_cache();
+        self.collect_missing_repo_paths()
     }
 
-    fn prune_git_cache(&mut self) {
+    fn prune_repo_cache(&mut self) {
         let mut active_paths = HashSet::new();
         for ws in &self.workspaces {
             for tab in &ws.tabs {
@@ -217,8 +254,59 @@ impl AppState {
                 }
             }
         }
-        self.git_info_cache
-            .retain(|path, _| active_paths.contains(path));
+        self.repo_info_cache.retain(|cache_key, info| {
+            active_paths.contains(cache_key)
+                || info.repo_root.as_ref().is_some_and(|repo_root| {
+                    let repo_root = Path::new(repo_root);
+                    active_paths
+                        .iter()
+                        .any(|path| Path::new(path).starts_with(repo_root))
+                })
+        });
+        self.pending_repo_paths
+            .retain(|path| active_paths.contains(path));
+    }
+
+    fn collect_missing_repo_paths(&mut self) -> Vec<String> {
+        let mut missing_paths = Vec::new();
+
+        for ws in &self.workspaces {
+            for tab in &ws.tabs {
+                for pane in &tab.panes {
+                    if group::lookup_cached_git_info_for_path(&pane.path, &self.repo_info_cache)
+                        .is_some()
+                    {
+                        continue;
+                    }
+
+                    if self.pending_repo_paths.insert(pane.path.clone()) {
+                        missing_paths.push(pane.path.clone());
+                    }
+                }
+            }
+        }
+
+        missing_paths
+    }
+
+    fn store_repo_info(&mut self, path: String, info: PaneGitInfo) -> bool {
+        self.pending_repo_paths.remove(&path);
+
+        let mut changed = self
+            .repo_info_cache
+            .insert(path.clone(), info.clone())
+            .as_ref()
+            != Some(&info);
+
+        if let Some(repo_root) = info.repo_root.as_ref() {
+            changed |= self
+                .repo_info_cache
+                .insert(repo_root.clone(), info.clone())
+                .as_ref()
+                != Some(&info);
+        }
+
+        changed
     }
 
     /// Rebuild the flat list of selectable agent rows from groups.
@@ -279,11 +367,16 @@ impl AppState {
             .map(|target| target.pane_id)
             .collect();
 
-        if let Some(pane_id) = self.focused_pane_id {
+        if let Some(pane_id) = self.active_focus_pane_id() {
             tracked_panes.insert(pane_id);
         }
 
         tracked_panes
+    }
+
+    fn active_focus_pane_id(&self) -> Option<u64> {
+        self.focused_pane_id
+            .filter(|pane_id| self.find_pane(*pane_id).is_some())
     }
 
     fn refresh_activity_cache(&mut self, policy: ActivityCachePolicy) {
@@ -322,7 +415,7 @@ impl AppState {
 
     fn refresh_activity_view(&mut self) {
         let activity_pane_id = self
-            .focused_pane_id
+            .active_focus_pane_id()
             .or_else(|| self.agent_row_targets.first().map(|target| target.pane_id));
 
         self.activity_entries = activity_pane_id
@@ -344,17 +437,22 @@ impl AppState {
     }
 
     fn refresh_git_target(&mut self) -> Option<String> {
-        let path = self.focused_pane_id.and_then(|pane_id| {
+        let path = self.active_focus_pane_id().and_then(|pane_id| {
             self.repo_groups
                 .iter()
                 .flat_map(|group| group.panes.iter())
                 .find(|(pane, _)| pane.pane_id == pane_id)
-                .map(|(pane, _)| pane.path.clone())
+                .map(|(pane, git_info)| {
+                    git_info
+                        .repo_root
+                        .clone()
+                        .unwrap_or_else(|| pane.path.clone())
+                })
         });
 
         if path != self.last_git_path {
             self.last_git_path = path.clone();
-            return path;
+            return Some(path.unwrap_or_default());
         }
 
         None
@@ -469,31 +567,11 @@ mod tests {
         }
     }
 
-    fn make_pane_with_path(pane_id: u64, status: PaneStatus, path: &str) -> PaneInfo {
-        let mut pane = make_pane(pane_id, status);
-        pane.path = path.into();
-        pane
-    }
-
     fn make_git_info() -> PaneGitInfo {
         PaneGitInfo {
             repo_root: Some("/tmp/test".into()),
             branch: Some("main".into()),
             is_worktree: false,
-        }
-    }
-
-    fn make_cached_activity(label: &str, progress: TaskProgress) -> CachedActivity {
-        CachedActivity {
-            fingerprint: LogFingerprint::missing(),
-            snapshot: ActivitySnapshot {
-                display_entries: vec![ActivityEntry {
-                    timestamp: "14:32".into(),
-                    tool: "Bash".into(),
-                    label: label.into(),
-                }],
-                task_progress: progress,
-            },
         }
     }
 
@@ -781,6 +859,53 @@ mod tests {
         // Should have been reset to All
         assert_eq!(state.repo_filter, RepoFilter::All);
     }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::group::{PaneGitInfo, RepoGroup};
+    use crate::wezterm::{AgentType, PaneInfo, PaneStatus, PermissionMode, WorkspaceInfo};
+
+    fn make_pane(pane_id: u64, status: PaneStatus) -> PaneInfo {
+        PaneInfo {
+            pane_id,
+            tab_id: 0,
+            window_id: 0,
+            workspace: "default".into(),
+            pane_active: false,
+            status,
+            attention: false,
+            agent: AgentType::Claude,
+            path: "/tmp/test".into(),
+            prompt: String::new(),
+            prompt_is_response: false,
+            started_at: None,
+            wait_reason: String::new(),
+            permission_mode: PermissionMode::Default,
+            subagents: Vec::new(),
+        }
+    }
+
+    fn make_pane_with_path(pane_id: u64, status: PaneStatus, path: &str) -> PaneInfo {
+        let mut pane = make_pane(pane_id, status);
+        pane.path = path.into();
+        pane
+    }
+
+    fn make_cached_activity(label: &str, progress: TaskProgress) -> CachedActivity {
+        CachedActivity {
+            fingerprint: LogFingerprint::missing(),
+            snapshot: ActivitySnapshot {
+                display_entries: vec![ActivityEntry {
+                    timestamp: "14:32".into(),
+                    tool: "Bash".into(),
+                    label: label.into(),
+                }],
+                task_progress: progress,
+            },
+        }
+    }
 
     #[test]
     fn test_refresh_local_views_updates_filters_without_snapshot_refresh() {
@@ -853,5 +978,90 @@ mod tests {
         assert!(state.pane_task_progress.contains_key(&2));
         assert!(state.activity_cache.contains_key(&1));
         assert!(state.activity_cache.contains_key(&2));
+    }
+
+    #[test]
+    fn test_refresh_local_views_ignores_stale_focused_pane() {
+        let pane1 = make_pane_with_path(1, PaneStatus::Running, "/repo-a");
+        let mut state = AppState::new(999);
+        state.repo_groups = vec![RepoGroup {
+            id: "/repo-a".into(),
+            name: "repo-a".into(),
+            has_focus: true,
+            panes: vec![(
+                pane1,
+                PaneGitInfo {
+                    repo_root: Some("/repo-a".into()),
+                    branch: Some("main".into()),
+                    is_worktree: false,
+                },
+            )],
+        }];
+        state.focused_pane_id = Some(42);
+        state.activity_cache.insert(
+            1,
+            make_cached_activity(
+                "visible activity",
+                TaskProgress {
+                    tasks: vec![("1".into(), activity::TaskStatus::InProgress)],
+                },
+            ),
+        );
+        state.activity_cache.insert(
+            42,
+            make_cached_activity(
+                "stale activity",
+                TaskProgress {
+                    tasks: vec![("2".into(), activity::TaskStatus::Completed)],
+                },
+            ),
+        );
+
+        let git_path = state.refresh_local_views();
+
+        assert_eq!(git_path, None);
+        assert_eq!(state.activity_entries.len(), 1);
+        assert_eq!(state.activity_entries[0].label, "visible activity");
+        assert_eq!(state.pane_task_progress.len(), 1);
+        assert!(state.pane_task_progress.contains_key(&1));
+        assert!(!state.activity_cache.contains_key(&42));
+    }
+
+    #[test]
+    fn test_apply_repo_info_updates_retargets_git_path_to_repo_root() {
+        let pane = make_pane_with_path(1, PaneStatus::Running, "/repo-a/src");
+        let mut state = AppState::new(999);
+        state.workspaces = vec![WorkspaceInfo {
+            workspace_name: "default".into(),
+            tabs: vec![crate::wezterm::TabInfo {
+                tab_id: 1,
+                tab_title: "tab".into(),
+                tab_active: true,
+                panes: vec![pane.clone()],
+            }],
+        }];
+        state.focused_pane_id = Some(1);
+        state.repo_groups = vec![RepoGroup {
+            id: "/repo-a/src".into(),
+            name: "src".into(),
+            has_focus: true,
+            panes: vec![(pane, PaneGitInfo::default())],
+        }];
+        state.last_git_path = Some("/repo-a/src".into());
+
+        let actions = state.apply_repo_info_updates(vec![RepoInfoUpdate {
+            path: "/repo-a/src".into(),
+            info: PaneGitInfo {
+                repo_root: Some("/repo-a".into()),
+                branch: Some("main".into()),
+                is_worktree: false,
+            },
+        }]);
+
+        assert_eq!(actions.git_path.as_deref(), Some("/repo-a"));
+        assert!(actions.repo_paths.is_empty());
+        assert_eq!(state.repo_groups.len(), 1);
+        assert_eq!(state.repo_groups[0].id, "/repo-a");
+        assert_eq!(state.repo_groups[0].name, "repo-a");
     }
 }


### PR DESCRIPTION
## 概要
- repo/git 更新処理のキャッシュ化と worker 化で UI 側の同期負荷を減らす
- worker 系の統合寄りテストを追加する
- CI と release workflow で unit と integration テストを分離する

## テスト計画
- [x] cargo test -- --skip integration_tests::
- [x] cargo test integration_tests::
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check