### PR TITLE
Claude設定でcargo実行を許可

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": {
+      "Bash(cargo *)"
+    }
+  }
+}


### PR DESCRIPTION
## 概要
- `.claude/settings.json` を追加する
- Claude のローカル設定で `cargo` コマンド実行を許可する

## テスト計画
- [ ] 設定ファイル追加のみのため未実施