### PR TITLE
Codex用cargoルールを追加

### DIFF
--- a/.codex/rules/cargo.rules
+++ b/.codex/rules/cargo.rules
@@ -1,0 +1,13 @@
+prefix_rule(
+    pattern = ["cargo"],
+    decision = "allow",
+    justification = "Rust 開発で使う cargo コマンドを許可する",
+    match = [
+        "cargo test",
+        "cargo build --release",
+        "cargo fmt --check",
+    ],
+    not_match = [
+        "git cargo test",
+    ],
+)


### PR DESCRIPTION
Codex の execpolicy 用ルールを追加し、cargo コマンドが allow 判定になることを確認した。\n既存の Claude 設定用 PR とは分離するため、別ブランチで管理する。