### PR TITLE
activityログのラベル切り詰めを安全化

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -257,15 +257,7 @@ fn write_activity_entry(pane_id: &str, tool_name: &str, label: &str) {
     let path = activity_log_path(pane_id);
     let hhmm = local_time_hhmm();
 
-    // Truncate label for display
-    let label = if label.len() > 200 {
-        &label[..200]
-    } else {
-        label
-    };
-
-    // Replace newlines and pipes in label
-    let label = label.replace(['\n', '|'], " ");
+    let label = format_activity_label(label, 200);
 
     let entry = format!("{hhmm}|{tool_name}|{label}\n");
 
@@ -275,6 +267,11 @@ fn write_activity_entry(pane_id: &str, tool_name: &str, label: &str) {
 
     // Trim log if too large
     trim_log_file(&path, 200, 210);
+}
+
+fn format_activity_label(label: &str, max_chars: usize) -> String {
+    let sanitized = label.replace(['\n', '|'], " ");
+    sanitized.chars().take(max_chars).collect()
 }
 
 fn trim_log_file(path: &PathBuf, keep: usize, threshold: usize) {
@@ -327,6 +324,19 @@ mod tests {
     fn test_activity_log_path() {
         let path = activity_log_path("42");
         assert_eq!(path, PathBuf::from("/tmp/wezterm-agent-activity-42.log"));
+    }
+
+    #[test]
+    fn test_format_activity_label_truncates_on_utf8_boundary() {
+        let label = "あ".repeat(100);
+        let truncated = format_activity_label(&label, 67);
+        assert_eq!(truncated, "あ".repeat(67));
+    }
+
+    #[test]
+    fn test_format_activity_label_sanitizes_separators() {
+        let label = "line1\nline2|line3";
+        assert_eq!(format_activity_label(label, 200), "line1 line2 line3");
     }
 
     #[test]


### PR DESCRIPTION
## 概要
- activity log のラベル整形を helper 化し、UTF-8 文字境界を壊さずに切り詰めるようにしました。
- 改行と pipe の sanitize を同じ helper に集約しました。
- 日本語ラベルの切り詰めと separator sanitize のテストを追加しました。

Fixes #21

## テスト計画
- [x] `cargo fmt --check`
- [x] `cargo test cli::hook::tests::test_format_activity_label`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features`