### PR TITLE
repo popupの移動入力を優先

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,19 @@ fn run_app(
                             send_git_path(state.refresh_local_views(), &git_path_tx);
                         }
 
+                        // Popup navigation
+                        (KeyCode::Char('j') | KeyCode::Down, _) if state.repo_popup_open => {
+                            let max = state.repo_entries().len();
+                            if state.repo_popup_selected < max {
+                                state.repo_popup_selected += 1;
+                            }
+                        }
+                        (KeyCode::Char('k') | KeyCode::Up, _)
+                            if state.repo_popup_open && state.repo_popup_selected > 0 =>
+                        {
+                            state.repo_popup_selected -= 1;
+                        }
+
                         // Agent list navigation
                         (KeyCode::Char('j') | KeyCode::Down, _) if state.focus == Focus::Agents => {
                             state.select_next();
@@ -175,19 +188,6 @@ fn run_app(
                         (KeyCode::Char('r'), _) if state.focus == Focus::Agents => {
                             state.repo_popup_open = !state.repo_popup_open;
                             state.repo_popup_selected = 0;
-                        }
-
-                        // Popup navigation
-                        (KeyCode::Char('j') | KeyCode::Down, _) if state.repo_popup_open => {
-                            let max = state.repo_entries().len();
-                            if state.repo_popup_selected < max {
-                                state.repo_popup_selected += 1;
-                            }
-                        }
-                        (KeyCode::Char('k') | KeyCode::Up, _)
-                            if state.repo_popup_open && state.repo_popup_selected > 0 =>
-                        {
-                            state.repo_popup_selected -= 1;
                         }
 
                         // Escape closes popup or clears filter


### PR DESCRIPTION
## 概要
- repo filter popup が開いているときの `j/k` と上下キーを agent list navigation より先に処理するようにしました。
- popup 操作中に背後の agent 選択が動かないようにしました。
- main 側で scroll state は既に整理済みのため、この PR では残っていた popup 入力順の不具合に絞っています。

Fixes #8

## テスト計画
- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features`